### PR TITLE
Enforce architecture standards with automated checks and refactor CI pipeline  

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,75 +1,90 @@
-name: Vercel Build & Deploy
+name: Build & Deploy
+
+# Runs only when code lands on a deployable branch (after PR merge or direct push).
+# PR quality checks (lint, format, TypeScript, architecture) are handled separately
+# by pr-checks.yml and must pass before any PR can be merged.
+#
+# This workflow has one job — deploying to Vercel. But it includes a quick pre-deploy
+# safety net (arch-check + build) to catch any issues from direct pushes that bypassed
+# the normal PR flow.
 
 on:
   push:
     branches:
-      - '**'
-  pull_request:
-    branches:
-      - '**'
+      - main     # → deploys to Vercel Production
+      - develop  # → deploys to Vercel Preview
 
 jobs:
-  build-and-deploy:
-    name: Build & Lint
+  # ─── Job 1: Verify ───────────────────────────────────────────────────────────
+  # Fast pre-deploy safety check. Ensures the code is structurally sound
+  # and compiles before we attempt a deployment.
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Set DATABASE_URL
-        run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "DATABASE_URL=${{ secrets.PROD_DATABASE_URL }}" >> $GITHUB_ENV
-          else
-            echo "DATABASE_URL=${{ secrets.DEV_DATABASE_URL }}" >> $GITHUB_ENV
-          fi
-
-      - name: Set API Base URL
-        run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "NEXT_PUBLIC_API_BASE_URL=https://invent-delta.vercel.app/api" >> $GITHUB_ENV
-          else
-            echo "NEXT_PUBLIC_API_BASE_URL=https://invent-dushyantpant5-dushyantpant5s-projects.vercel.app/api" >> $GITHUB_ENV
-          fi
-
       - name: Generate Prisma Client
         run: npx prisma generate
 
-      - name: Run ESLint
-        run: npx eslint . --max-warnings=0
+      - name: Architecture check
+        # Catches critical structural violations (new PrismaClient, missing
+        # withErrorHandling, side effects in API functions, etc.) as a safety
+        # net for any code that reached this branch without going through a PR.
+        run: npm run arch-check
 
-      - name: Build project
+      - name: Build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_API_BASE_URL: ${{ env.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_API_BASE_URL: ${{ github.ref == 'refs/heads/main' && 'https://invent-delta.vercel.app/api' || 'https://invent-dushyantpant5-dushyantpant5s-projects.vercel.app/api' }}
+          DATABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.PROD_DATABASE_URL || secrets.DEV_DATABASE_URL }}
           USER_PAYLOAD_SECRET: ${{ secrets.USER_PAYLOAD_SECRET }}
         run: npm run build
 
+  # ─── Job 2: Deploy ───────────────────────────────────────────────────────────
+  # Deploys to Vercel only after the verify job passes.
+  # main   → Production deployment
+  # develop → Preview deployment
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: verify  # verify must pass before deploy runs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Install Vercel CLI
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
         run: npm install -g vercel
 
-      # Deploy to Vercel Production
       - name: Deploy to Vercel (Production)
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        if: github.ref == 'refs/heads/main'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          vercel --prod --yes --token=$VERCEL_TOKEN
+        run: vercel --prod --yes --token=$VERCEL_TOKEN
 
-      # Deploy to Vercel Preview
       - name: Deploy to Vercel (Preview)
-        if: ${{ github.ref == 'refs/heads/develop' && github.event_name == 'push' }}
+        if: github.ref == 'refs/heads/develop'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          vercel --yes --token=$VERCEL_TOKEN
+        run: vercel --yes --token=$VERCEL_TOKEN

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -11,8 +11,8 @@ name: Build & Deploy
 on:
   push:
     branches:
-      - main     # → deploys to Vercel Production
-      - develop  # → deploys to Vercel Preview
+      - main # → deploys to Vercel Production
+      - develop # → deploys to Vercel Preview
 
 jobs:
   # ─── Job 1: Verify ───────────────────────────────────────────────────────────
@@ -59,7 +59,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: verify  # verify must pass before deploy runs
+    needs: verify # verify must pass before deploy runs
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,124 @@
+name: PR Checks
+
+# Runs on every pull request targeting any branch.
+# These checks must pass before a PR can be merged.
+# Configure branch protection rules in GitHub Settings → Branches to enforce this.
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  # ─── Job 1: Lint ─────────────────────────────────────────────────────────────
+  # Checks code style, import boundaries, unused imports, and TypeScript lint rules.
+  # Any ESLint warning or error fails this job (--max-warnings=0).
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Run ESLint
+        run: npm run lint:ci
+
+  # ─── Job 2: Format ───────────────────────────────────────────────────────────
+  # Verifies Prettier formatting without modifying files.
+  # If this fails, run `npm run format` locally and commit the result.
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+  # ─── Job 3: TypeScript Build ─────────────────────────────────────────────────
+  # Runs the full Next.js production build.
+  # Catches TypeScript errors, missing imports, and broken JSX that lint alone misses.
+  build:
+    name: Build (TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Set required env vars for build
+        run: |
+          echo "NEXT_PUBLIC_API_BASE_URL=https://placeholder.example.com/api" >> $GITHUB_ENV
+          echo "USER_PAYLOAD_SECRET=ci-placeholder-secret-32-characters!!" >> $GITHUB_ENV
+
+      - name: Build
+        env:
+          NODE_ENV: production
+          NEXT_PUBLIC_API_BASE_URL: ${{ env.NEXT_PUBLIC_API_BASE_URL }}
+          USER_PAYLOAD_SECRET: ${{ env.USER_PAYLOAD_SECRET }}
+        run: npm run build
+
+  # ─── Job 4: Architecture Check ───────────────────────────────────────────────
+  # Runs the custom architecture enforcement script.
+  # Checks patterns that ESLint import rules cannot catch:
+  #   CRITICAL (exits 1 — blocks merge):
+  #     - new PrismaClient() outside repositories/index.ts
+  #     - Route handlers missing withErrorHandling
+  #     - Side effects (toasts, navigation) in feature API functions
+  #     - Services calling prisma model methods directly
+  #     - Repositories importing from services
+  #   WARNING (logged but does not block merge):
+  #     - console.log in server-side code
+  #     - useMutation used directly instead of useNavigatingMutation
+  #     - Inline type definitions in service files
+  arch-check:
+    name: Architecture Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run architecture check
+        run: npm run arch-check

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+#reports
+audit.md
+
+#claude
+.claude

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+# pre-commit: runs on every `git commit`
+# Lints and formats only the files staged for this commit (fast — not the whole codebase).
+# Fix all errors before the commit is accepted.
+
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,10 @@
+# pre-push: runs on every `git push`
+# Runs the full TypeScript build and architecture check before code leaves your machine.
+# This catches cross-file type errors and structural violations that lint-staged misses.
+# Fix all errors before the push is accepted.
+
+echo "Running architecture check..."
+npm run arch-check
+
+echo "Running full build (TypeScript + Next.js)..."
+npm run build

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,1251 @@
+# Invent — Developer Guide
+
+Welcome to the project. This document explains how the codebase is structured, how to work within it, and what rules to follow. Read it fully before writing any code.
+
+---
+
+## Table of Contents
+
+1. [Before You Commit — Required Checks](#1-before-you-commit--required-checks)
+2. [What This App Does](#2-what-this-app-does)
+3. [Tech Stack](#3-tech-stack)
+4. [Architecture Overview](#4-architecture-overview)
+5. [Folder Structure](#5-folder-structure)
+6. [The Request Lifecycle](#6-the-request-lifecycle)
+7. [API Routes](#7-api-routes)
+8. [Database Access — Repositories](#8-database-access--repositories)
+9. [Business Logic — Services](#9-business-logic--services)
+10. [TanStack Query — Data Fetching on the Client](#10-tanstack-query--data-fetching-on-the-client)
+11. [Validation with Zod](#11-validation-with-zod)
+12. [Error Handling](#12-error-handling)
+13. [Types and DTOs](#13-types-and-dtos)
+14. [Authentication Flow](#14-authentication-flow)
+15. [Adding a New Feature — Step-by-Step Checklist](#15-adding-a-new-feature--step-by-step-checklist)
+16. [Rules and Best Practices](#16-rules-and-best-practices)
+17. [Automated Enforcement — How Rules Are Enforced](#17-automated-enforcement--how-rules-are-enforced)
+18. [Known Limitations and Outstanding Items](#18-known-limitations-and-outstanding-items)
+19. [Common Mistakes to Avoid](#19-common-mistakes-to-avoid)
+
+---
+
+## 1. Before You Commit — Required Checks
+
+**Most of these checks run automatically** — Husky hooks enforce them at commit and push time. But you should also know how to run them manually when you need to debug a failure.
+
+### All available commands
+
+```bash
+# Fix linting errors and auto-format staged code
+npm run lint           # ESLint with --fix (run this to fix auto-fixable issues)
+npm run lint:ci        # ESLint with --max-warnings=0 (no fixes — used in CI)
+npm run format         # Prettier — rewrites files in place
+npm run format:check   # Prettier — checks only, no writes (used in CI)
+
+# Check architecture rules
+npm run arch-check     # Custom structural check (see section 17)
+
+# Verify the full build
+npm run build          # TypeScript + Next.js production build
+npm run dev            # Start dev server to test changes manually
+```
+
+### What runs automatically and when
+
+| Hook           | Trigger      | What runs                                              |
+| -------------- | ------------ | ------------------------------------------------------ |
+| **pre-commit** | `git commit` | `lint-staged` — ESLint + Prettier on staged files only |
+| **pre-push**   | `git push`   | `npm run arch-check` then `npm run build`              |
+
+> `lint-staged` is fast because it only lints the files you have actually changed, not the whole codebase. The full build runs on push so TypeScript cross-file errors are caught before your code reaches GitHub.
+
+### What runs on GitHub (CI)
+
+Four separate jobs run in parallel on every pull request. **All four must pass before a PR can be merged.**
+
+| CI Job                 | Command                | Blocks merge on                                 |
+| ---------------------- | ---------------------- | ----------------------------------------------- |
+| **Lint**               | `npm run lint:ci`      | Any ESLint error or warning                     |
+| **Format**             | `npm run format:check` | Any unformatted file                            |
+| **Build**              | `npm run build`        | TypeScript errors, broken imports, JSX errors   |
+| **Architecture Check** | `npm run arch-check`   | Critical structural violations (see section 17) |
+
+### If a hook fails
+
+- **pre-commit fails** — fix the ESLint or Prettier errors it reports, re-stage your files, and commit again. Do not use `--no-verify` to skip the hook.
+- **pre-push fails** — fix the error reported by `arch-check` or `build`, then push again.
+- **CI fails** — click the failing job in GitHub to read the full output, fix the issue locally, and push the fix.
+
+**Never use `git commit --no-verify` or `git push --no-verify` to bypass hooks.**
+
+---
+
+## 2. What This App Does
+
+Invent is an inventory management web application. Users can:
+
+- Create an account and sign in
+- Create a new inventory (they become the admin)
+- Join an existing inventory using a share code (they join as staff)
+- Manage products within their inventory
+
+---
+
+## 3. Tech Stack
+
+| Technology            | What it does                                                    |
+| --------------------- | --------------------------------------------------------------- |
+| **Next.js 15**        | The web framework — handles both the UI and the server-side API |
+| **TypeScript**        | Adds types to JavaScript — prevents entire categories of bugs   |
+| **Prisma**            | Talks to the database. You write TypeScript; Prisma writes SQL  |
+| **PostgreSQL**        | The database                                                    |
+| **TanStack Query v5** | Manages all data fetching and mutations on the client side      |
+| **Zod**               | Validates data shapes — ensures inputs are what you expect      |
+| **Axios**             | Makes HTTP requests from the browser to the API                 |
+| **jose**              | Creates and verifies JSON Web Tokens (JWTs) for auth            |
+| **bcryptjs**          | Hashes passwords before storing them                            |
+| **React Hook Form**   | Manages form state in React components                          |
+| **Tailwind CSS**      | Utility-first CSS framework for styling                         |
+| **sonner**            | Toast notification library                                      |
+
+---
+
+## 4. Architecture Overview
+
+### Design principles this codebase follows
+
+You will hear these terms used throughout the codebase and in code review. Here is what they mean in plain English:
+
+**SOLID — a set of five rules for writing maintainable code:**
+
+- **S — Single Responsibility Principle (SRP):** Every file, class, or function should do exactly one thing. A repository only queries the database. A service only contains business logic. An API function only makes HTTP calls. If something is doing two things, it should be split.
+
+- **O — Open/Closed Principle (OCP):** Code should be easy to extend without having to rewrite it. For example, the `buildApiClient` factory lets you create a new HTTP client in one line — you do not need to duplicate all the HTTP verb methods again.
+
+- **D — Dependency Inversion Principle (DIP):** High-level code should not depend on specific low-level implementations. For example, `useNavigatingMutation` depends on `ToastService` (an abstraction), not on `sonner` (the specific library) directly. This means swapping the toast library later requires changing only `toast.service.ts`.
+
+**DRY — Don't Repeat Yourself:**
+
+If you write the same code in two places, a bug fixed in one place will remain in the other. This codebase extracts repeated patterns into shared utilities (`withErrorHandling`, `useNavigatingMutation`, `buildApiClient`, `extractRequestMeta`, etc.) so there is one place to fix and one place to read.
+
+---
+
+The application uses a **layered architecture**. Each layer has one job and only talks to the layer directly below it.
+
+```
+Browser (React components)
+        │
+        │  HTTP requests (Axios)
+        ▼
+Next.js API Routes  ──► Middleware (auth guard)
+        │
+        │  calls
+        ▼
+   Services  (business logic)
+        │
+        │  calls
+        ▼
+  Repositories  (database queries)
+        │
+        │  calls
+        ▼
+    Prisma ORM
+        │
+        ▼
+   PostgreSQL DB
+```
+
+**Why layers matter:** Each layer only knows about the layer below it. A repository does not know about HTTP. A service does not know about React. A component does not write SQL. This keeps the code predictable and easy to change.
+
+### The three key rules
+
+1. **Components** call hooks from `features/`. They never call repositories or services directly.
+2. **Services** contain all business logic. They call repositories. They throw `ServiceError` when something goes wrong.
+3. **Repositories** only read and write the database. They throw `DatabaseError` and contain no business logic.
+
+---
+
+## 5. Folder Structure
+
+```
+src/
+├── app/                        # Next.js App Router
+│   ├── api/                    # Server-side API route handlers
+│   │   ├── auth/
+│   │   │   ├── signIn/route.ts
+│   │   │   ├── signUp/
+│   │   │   │   ├── request-signup/route.ts
+│   │   │   │   └── verify-otp/route.ts
+│   │   │   ├── refreshToken/route.ts
+│   │   │   └── getCoreToken/route.ts
+│   │   └── inventory/
+│   │       ├── create-inventory/route.ts
+│   │       └── join-inventory/route.ts
+│   └── (page routes, layouts, etc.)
+│
+├── features/                   # Client-side feature modules
+│   ├── auth/
+│   │   ├── auth.api.ts         # Pure async functions that call the API
+│   │   └── auth.queries.ts     # TanStack Query hooks (useRequestSignUp, etc.)
+│   ├── inventory/
+│   │   ├── inventory.api.ts
+│   │   └── inventory.queries.ts
+│   └── product/
+│       ├── product.api.ts
+│       └── product.queries.ts
+│
+├── services/                   # Server-side business logic
+│   ├── auth/
+│   │   ├── auth.service.ts     # Sign up, sign in, refresh, OTP
+│   │   ├── token-factory/      # JWT creation and verification
+│   │   ├── password-factory/   # bcrypt hashing and verification
+│   │   └── otp-factory/        # OTP generation and verification
+│   ├── inventory/
+│   │   └── inventory.service.ts
+│   ├── toast/
+│   │   └── toast.service.ts    # Wrapper around sonner
+│   └── lib.ts                  # ServiceError class
+│
+├── repositories/               # Database access (Prisma queries only)
+│   ├── index.ts                # Prisma client singleton
+│   ├── lib.ts                  # DatabaseError class
+│   ├── user.repo.ts
+│   ├── session.repo.ts
+│   ├── otp.repo.ts
+│   └── inventory.repo.ts
+│
+├── types/                      # TypeScript types and DTOs
+│   ├── index.ts                # INextResponse<T>
+│   ├── auth/
+│   │   └── auth.ts             # All auth-related DTOs and interfaces
+│   └── inventory/
+│       └── inventory.types.ts
+│
+├── validators/
+│   └── index.ts                # All Zod schemas (single source of truth)
+│
+├── lib/                        # Shared utilities
+│   ├── cookies/index.ts        # Cookie read/write/clear helpers
+│   ├── crypto/encryption.ts    # AES-GCM encrypt/decrypt
+│   ├── email/emailjs.ts        # Email sending via EmailJS
+│   ├── hooks/
+│   │   └── use-navigating-mutation.ts  # DRY TanStack Query mutation factory
+│   ├── http/
+│   │   ├── api-client.ts       # Axios client factory for feature modules
+│   │   ├── api-error.ts        # ApiError class + error message extractor
+│   │   ├── axios.ts            # Main Axios instance (standard API calls)
+│   │   └── core-axios.ts       # Axios instance for the core service (with JWT)
+│   ├── query-client.ts         # TanStack QueryClient configuration
+│   ├── query-keys.ts           # Centralized query key factory
+│   └── route-helpers.ts        # withErrorHandling HOF, parseJsonBody, etc.
+│
+├── constants/                  # App-wide constants
+│   ├── tokens.constant.ts      # Cookie names, token TTLs
+│   └── otp.constant.ts         # OTP TTL
+│
+├── providers/
+│   └── ReactQueryProvider.tsx  # Wraps the app with TanStack QueryClientProvider
+│
+├── middleware.ts               # Auth guard — protects /dashboard and /inventory
+└── components/                 # Shared UI components
+```
+
+---
+
+## 6. The Request Lifecycle
+
+Here is the exact path a user action takes through the system. Understanding this will help you know where to add your code.
+
+### Example: User clicks "Sign In"
+
+```
+1. Component (login-form.tsx)
+   └─ calls useRequestLogIn().mutate({ email, password })
+
+2. useRequestLogIn (features/auth/auth.queries.ts)
+   └─ calls requestLogIn(email, password) via useNavigatingMutation
+
+3. requestLogIn (features/auth/auth.api.ts)
+   └─ validates with Zod
+   └─ calls POST /api/auth/signIn via Axios
+
+4. POST /api/auth/signIn (app/api/auth/signIn/route.ts)
+   └─ parses and validates request body
+   └─ calls AuthService.handleSignInUser(...)
+
+5. AuthService.handleSignInUser (services/auth/auth.service.ts)
+   └─ calls UserRepository.getUserByEmail(email)
+   └─ verifies password with PasswordFactory
+   └─ calls SessionRepository.createSession(...)
+   └─ calls TokenFactory.getAccessToken(...)
+   └─ returns { message, accessToken, refreshToken }
+
+6. Route handler
+   └─ sets access/refresh tokens as httpOnly cookies
+   └─ returns 200 { message }
+
+7. useNavigatingMutation onSuccess
+   └─ shows success toast
+   └─ navigates to /dashboard
+```
+
+---
+
+## 7. API Routes
+
+API routes live in `src/app/api/`. Each file exports named HTTP method functions (`GET`, `POST`, etc.).
+
+### Pattern — every route follows this exact structure
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { mySchema } from '@/validators';
+import { MyService } from '@/services/my/my.service';
+import { withErrorHandling, parseJsonBody, validationErrorResponse } from '@/lib/route-helpers';
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  // 1. Parse the request body safely
+  const body = await parseJsonBody(request);
+
+  // 2. Validate with Zod
+  const validation = mySchema.safeParse(body);
+  if (!validation.success) return validationErrorResponse(validation.error);
+
+  // 3. Call the service
+  const result = await MyService.doSomething(validation.data);
+
+  // 4. Return a response
+  return NextResponse.json({ data: result }, { status: 201 });
+});
+```
+
+### What `withErrorHandling` does
+
+`withErrorHandling` is a wrapper (called a Higher-Order Function) that removes the need for `try/catch` in every route. If anything throws — a `ServiceError`, `DatabaseError`, or an unexpected crash — `withErrorHandling` catches it and returns the correct HTTP error response automatically.
+
+```
+ServiceError('message', 409)  →  HTTP 409 { error: 'message' }
+DatabaseError('message')      →  HTTP 500 { error: 'message' }
+Unexpected Error              →  HTTP 500 { error: error.message }
+```
+
+**Never wrap route logic in a try/catch manually.** Let `withErrorHandling` do it.
+
+### HTTP status codes — use the correct one
+
+| Status | When to use                                          |
+| ------ | ---------------------------------------------------- |
+| `200`  | Successful read or action (sign in, token refresh)   |
+| `201`  | A new resource was created (new user, new inventory) |
+| `400`  | Invalid input from the client                        |
+| `401`  | Not authenticated (no valid session)                 |
+| `403`  | Authenticated but not allowed (wrong role)           |
+| `404`  | Resource does not exist                              |
+| `409`  | Conflict (e.g. email already registered)             |
+| `500`  | Something went wrong on the server                   |
+
+**Never put a `status` field inside the JSON body.** The HTTP status code IS the status. The body only contains `data` or `error`.
+
+```ts
+// CORRECT
+return NextResponse.json({ data: result }, { status: 201 });
+return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+// WRONG — do not do this
+return NextResponse.json({ data: result, status: 201 });
+```
+
+### Extracting request metadata
+
+When you need the user's IP address or browser info (e.g. for session tracking):
+
+```ts
+import { extractRequestMeta } from '@/lib/route-helpers';
+
+const { userAgent, ipAddress } = extractRequestMeta(request);
+```
+
+---
+
+## 8. Database Access — Repositories
+
+Repositories are the **only** place that talks to the database. They live in `src/repositories/`.
+
+### Rules for repositories
+
+- **Only Prisma queries.** No business logic, no validation, no `console.error`, no `if` guards that belong to the service.
+- **Wrap every query in try/catch** and throw `DatabaseError` on failure.
+- **Use DTOs** (typed input objects) for methods with multiple parameters.
+- **Never call another repository's methods** from inside a repository.
+
+### Pattern — a repository method
+
+```ts
+import { prisma } from './index';
+import { DatabaseError } from './lib';
+
+export class ProductRepository {
+  static async getProductById(productId: string) {
+    try {
+      return await prisma.products.findUnique({ where: { id: productId } });
+    } catch {
+      throw new DatabaseError('Failed to fetch product');
+    }
+  }
+
+  static async createProduct(data: ICreateProductDTO) {
+    const { name, quantity, inventoryId, tx = prisma } = data;
+    try {
+      return await tx.products.create({
+        data: { name, quantity, inventoryId },
+      });
+    } catch {
+      throw new DatabaseError('Failed to create product');
+    }
+  }
+}
+```
+
+### Using transactions
+
+When multiple database writes must succeed or fail together (atomically), use a Prisma transaction. Transactions are always started in the **service layer** and passed to repositories as `tx`.
+
+```ts
+// In a service:
+await prisma.$transaction(async (tx) => {
+  const product = await ProductRepository.createProduct({ ...data, tx });
+  await AuditRepository.logCreation({ productId: product.id, tx });
+  // If either throws, both are rolled back automatically.
+});
+```
+
+The repository method must accept an optional `tx` parameter. See `ICreateSessionDTO` in `src/types/auth/auth.ts` for an example of how to type it:
+
+```ts
+import { Prisma } from '@prisma/client';
+
+export interface ICreateProductDTO {
+  name: string;
+  quantity: number;
+  inventoryId: string;
+  tx?: Prisma.TransactionClient;
+}
+```
+
+### The Prisma singleton
+
+`src/repositories/index.ts` exports a single shared `prisma` client instance. **Always import from there** — never create `new PrismaClient()` anywhere else.
+
+```ts
+import prisma from '@/repositories';
+// or for repositories:
+import { prisma } from './index';
+```
+
+---
+
+## 9. Business Logic — Services
+
+Services live in `src/services/`. They contain all the rules and decisions for how the application behaves.
+
+### Rules for services
+
+- **All business logic lives here.** If you are making a decision (e.g. "does the user already exist?"), it belongs in a service.
+- **Call repositories to read and write data.** Never write Prisma queries directly in a service.
+- **Throw `ServiceError`** with a meaningful message and the correct HTTP status code when something is wrong.
+- **Never reference HTTP, `NextRequest`, or `NextResponse`** — services must not know they are running inside a web server.
+- **Never import from `features/`** — services do not know the client side exists.
+
+### Pattern — a service method
+
+```ts
+import { ServiceError } from '../lib';
+import { ProductRepository } from '@/repositories/product.repo';
+
+export class ProductService {
+  static async getProduct(productId: string) {
+    const product = await ProductRepository.getProductById(productId);
+
+    if (!product) {
+      throw new ServiceError('Product not found', 404);
+    }
+
+    return product;
+  }
+
+  static async createProduct(data: { name: string; inventoryId: string }) {
+    const existing = await ProductRepository.findByNameInInventory(data);
+
+    if (existing) {
+      throw new ServiceError('A product with this name already exists', 409);
+    }
+
+    return ProductRepository.createProduct(data);
+  }
+}
+```
+
+### ServiceError status codes
+
+```ts
+throw new ServiceError('Not found', 404); // resource missing
+throw new ServiceError('Already exists', 409); // conflict
+throw new ServiceError('Not allowed', 403); // no permission
+throw new ServiceError('Please sign in', 401); // not authenticated
+throw new ServiceError('Something broke', 500); // unexpected failure
+```
+
+The default status code when you omit the second argument is `400`.
+
+---
+
+## 10. TanStack Query — Data Fetching on the Client
+
+TanStack Query manages all server state on the client side — fetching data, caching it, and running mutations (create / update / delete actions).
+
+> **New to TanStack Query?** Think of it as a smart assistant that remembers data you've already loaded (cache), re-fetches it when it might be out of date, and handles loading/error states for you — so you don't have to manage any of that manually.
+
+### The two-file pattern
+
+Every feature has exactly two files:
+
+| File                 | Job                                                                       |
+| -------------------- | ------------------------------------------------------------------------- |
+| `feature.api.ts`     | Pure async functions that make HTTP calls. No React, no hooks, no toasts. |
+| `feature.queries.ts` | React hooks built on top of the API functions. Own all side effects.      |
+
+This separation means you can test API functions in isolation, and components only ever import from `queries.ts`.
+
+### Mutations — `useNavigatingMutation`
+
+For any action that **changes data** (sign in, create inventory, submit a form), use the `useNavigatingMutation` factory from `src/lib/hooks/use-navigating-mutation.ts`.
+
+**Never use `useMutation` directly in feature files.** Always go through `useNavigatingMutation`.
+
+```ts
+// features/my-feature/my-feature.queries.ts
+'use client';
+
+import { myApiFunction } from './my-feature.api';
+import { useNavigatingMutation } from '@/lib/hooks/use-navigating-mutation';
+
+export const useDoSomething = () =>
+  useNavigatingMutation({
+    mutationFn: (variables: { name: string }) => myApiFunction(variables.name),
+
+    // Optional: where to navigate after success
+    redirectTo: '/dashboard',
+
+    // Optional: toast shown on success
+    successMessage: 'Done!',
+
+    // Optional: override the error toast message.
+    // If omitted, the server's error message is shown automatically.
+    errorMessage: 'Something went wrong. Please try again',
+
+    // Optional: dynamic error message based on the actual error
+    errorMessage: (error) => `Failed: ${error.message}`,
+
+    // Optional: extra callback after success (e.g. reset a form)
+    onSuccess: (data) => console.log(data),
+  });
+```
+
+`useNavigatingMutation` automatically:
+
+- Shows a success toast (if `successMessage` is provided)
+- Navigates to `redirectTo` after success
+- Shows an error toast on failure (using the server's message if `errorMessage` is not provided)
+- Logs the error to the console
+
+### Using a mutation in a component
+
+```tsx
+// components/my-form.tsx
+'use client';
+
+import { useDoSomething } from '@/features/my-feature/my-feature.queries';
+
+export function MyForm() {
+  const { mutate, isPending } = useDoSomething();
+
+  return (
+    <button onClick={() => mutate({ name: 'Example' })} disabled={isPending}>
+      {isPending ? 'Loading...' : 'Submit'}
+    </button>
+  );
+}
+```
+
+### Queries — reading data
+
+For **reading data** (e.g. fetching a list of products), use `useQuery` directly in the feature's `.queries.ts` file:
+
+```ts
+// features/product/product.queries.ts
+import { useQuery } from '@tanstack/react-query';
+import { getAllProducts } from './product.api';
+import { queryKeys } from '@/lib/query-keys';
+
+export const useProducts = () =>
+  useQuery({
+    queryKey: queryKeys.products.all(),
+    queryFn: getAllProducts,
+    throwOnError: false,
+  });
+```
+
+### QueryClient configuration
+
+The QueryClient is configured in `src/lib/query-client.ts` with two important settings:
+
+```ts
+mutations: { retry: 0 }          // never retry mutations
+queries:   { retry: 1, staleTime: 30_000 }  // cache for 30 seconds
+```
+
+**Why `retry: 0` for mutations?** TanStack Query retries failed requests by default. For read operations (queries) this is fine — retrying "fetch products" is safe. But for write operations (mutations), retrying "submit sign up" or "create inventory" could create **duplicate records** in the database. Mutations must never be retried automatically.
+
+**Why `staleTime: 30_000`?** Without a stale time, TanStack Query re-fetches data every time a component mounts. Setting 30 seconds means data is considered fresh for 30 seconds, which reduces unnecessary network requests.
+
+### Query keys
+
+Every `useQuery` call needs a `queryKey`. This is how TanStack Query identifies cached data. **Always use the centralized factory in `src/lib/query-keys.ts`** — never write magic strings inline.
+
+```ts
+// CORRECT
+queryKey: queryKeys.products.all(); // ['products']
+queryKey: queryKeys.products.detail(id); // ['products', 'abc-123']
+
+// WRONG — do not do this
+queryKey: ['products'];
+queryKey: ['products', id];
+```
+
+**Adding a new query key:**
+
+```ts
+// src/lib/query-keys.ts
+export const queryKeys = {
+  products: {
+    all: () => ['products'] as const,
+    detail: (id: string) => ['products', id] as const,
+  },
+  inventory: { ... },
+  // Add your new domain here:
+  orders: {
+    all: () => ['orders'] as const,
+    byInventory: (inventoryId: string) => ['orders', inventoryId] as const,
+  },
+} as const;
+```
+
+### The API function — `feature.api.ts`
+
+The API file contains plain async functions. **They must follow this contract exactly:**
+
+1. Client-side Zod validation → throw `ApiError(formatZodError(err))` if invalid
+2. HTTP call via the axios client
+3. Return typed data, or throw `ApiError` / let `AxiosError` propagate naturally
+4. **No toasts. No `console.error`. No side effects of any kind.**
+
+This keeps the function testable in isolation and means every error surface is handled in exactly one place (the hook).
+
+**Why are API functions kept pure?** Before this pattern was established, each API function had its own toast calls and error logging. Some errors showed toasts, others were silent. Some logged to console, others did not. The result was an inconsistent user experience and duplicate code across every function. The pure API function + side-effect hook split guarantees consistency: every mutation always shows the right toast, always logs errors, and always navigates on success — regardless of who wrote it.
+
+```ts
+// features/product/product.api.ts
+import { createApiClient } from '@/lib/http/api-client';
+import { ApiError, formatZodError } from '@/lib/http/api-error';
+import { createProductSchema } from '@/validators';
+import type { INextResponse } from '@/types';
+
+const productClient = createApiClient('/products');
+
+export const createProduct = async (name: string, quantity: number): Promise<void> => {
+  const validation = createProductSchema.safeParse({ name, quantity });
+  if (!validation.success) throw new ApiError(formatZodError(validation.error));
+
+  await productClient.post('/create', { name, quantity });
+};
+
+export const getAllProducts = async () => {
+  const response = await productClient.get<INextResponse<Product[]>>('/list');
+  return response.data;
+};
+```
+
+### The two Axios clients
+
+The app has two HTTP clients:
+
+| Client       | Used for                                                | How to get one                     |
+| ------------ | ------------------------------------------------------- | ---------------------------------- |
+| Standard     | Calls to `/api/*` routes                                | `createApiClient('/path')`         |
+| Core service | Calls to external inventory core service (requires JWT) | `createCoreServiceClient('/path')` |
+
+Most features will use `createApiClient`. Only use `createCoreServiceClient` for calls to the external core service.
+
+---
+
+## 11. Validation with Zod
+
+All validation schemas live in `src/validators/index.ts`. **Add new schemas there — do not create schema files elsewhere.**
+
+### What Zod does
+
+Zod checks that data matches the shape you expect. For example:
+
+```ts
+const createProductSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name is too long'),
+  quantity: z.number().int().min(0, 'Quantity cannot be negative'),
+});
+
+const result = createProductSchema.safeParse(userInput);
+
+if (!result.success) {
+  // result.error contains all the validation messages
+  console.log(result.error.issues); // [{ message: 'Name is required', path: ['name'] }]
+}
+```
+
+### Where validation runs
+
+Validation runs in **two places**:
+
+1. **Client side** (`feature.api.ts`) — catches obvious mistakes before making a network request, giving instant feedback
+2. **Server side** (API route) — the authoritative check; never trust client-submitted data
+
+Both use the **same schemas** from `src/validators/index.ts`. One source of truth.
+
+### Adding a new schema
+
+```ts
+// src/validators/index.ts
+export const createProductSchema = z.object({
+  name: z.string().min(1, 'Product name is required').max(100),
+  quantity: z.number().int().min(0),
+});
+```
+
+Then use it in the route:
+
+```ts
+const validation = createProductSchema.safeParse(body);
+if (!validation.success) return validationErrorResponse(validation.error);
+```
+
+And in the API function:
+
+```ts
+const validation = createProductSchema.safeParse({ name, quantity });
+if (!validation.success) throw new ApiError(formatZodError(validation.error));
+```
+
+---
+
+## 12. Error Handling
+
+The error system is unified across all layers. Here is how errors flow.
+
+### Error classes
+
+| Class                                   | Where thrown              | HTTP meaning                             |
+| --------------------------------------- | ------------------------- | ---------------------------------------- |
+| `DatabaseError` (`repositories/lib.ts`) | Repositories              | Always maps to 500                       |
+| `ServiceError` (`services/lib.ts`)      | Services                  | Maps to whatever status code you pass in |
+| `ApiError` (`lib/http/api-error.ts`)    | Client-side API functions | Shown to the user as a toast             |
+
+### Server-side flow
+
+```
+Repository throws DatabaseError  ──►  withErrorHandling  ──►  HTTP 500
+Service throws ServiceError(404) ──►  withErrorHandling  ──►  HTTP 404
+Unexpected throw                 ──►  withErrorHandling  ──►  HTTP 500
+```
+
+No route file needs a try/catch. `withErrorHandling` handles everything.
+
+### Client-side flow
+
+```
+ApiError thrown in feature.api.ts
+  └─► Caught by useNavigatingMutation's onError
+       └─► If errorMessage prop is set → show that message as toast
+       └─► If not → extractApiErrorMessage(error) reads the server's { error } field
+```
+
+`extractApiErrorMessage` handles three cases:
+
+- `AxiosError` with a response → reads `response.data.error`
+- `ApiError` or any `Error` → reads `error.message`
+- Unknown → returns a generic message
+
+### Never swallow errors silently
+
+```ts
+// WRONG — this hides the error
+try {
+  await doSomething();
+} catch {
+  // nothing
+}
+
+// CORRECT — always rethrow or handle meaningfully
+try {
+  await doSomething();
+} catch {
+  throw new DatabaseError('Failed to do something');
+}
+```
+
+---
+
+## 13. Types and DTOs
+
+A **DTO** (Data Transfer Object) is a TypeScript interface that describes the shape of data being passed between layers.
+
+### Where types live
+
+| File                                     | Contains                                           |
+| ---------------------------------------- | -------------------------------------------------- |
+| `src/types/index.ts`                     | `INextResponse<T>` — wrapper for API response data |
+| `src/types/auth/auth.ts`                 | All auth and session DTOs                          |
+| `src/types/inventory/inventory.types.ts` | All inventory DTOs                                 |
+
+**Add new types to the appropriate domain file in `src/types/`.** Do not define interfaces inline inside service or route files.
+
+### Naming conventions
+
+- All interfaces and types start with `I` or are a `Type`: `ICreateProductDTO`, `IProductResponseDTO`
+- DTOs for database input end in `DatabaseRequestDTO`
+- DTOs for service input end in just `DTO`
+- DTOs for HTTP responses end in `ResponseDTO`
+
+### Example — adding types for a new domain
+
+```ts
+// src/types/product/product.types.ts
+import { Prisma } from '@prisma/client';
+
+export interface ICreateProductDTO {
+  name: string;
+  quantity: number;
+  inventoryId: string;
+  tx?: Prisma.TransactionClient;
+}
+
+export interface IProductResponseDTO {
+  id: string;
+  name: string;
+  quantity: number;
+}
+```
+
+---
+
+## 14. Authentication Flow
+
+Understanding how auth works helps you protect routes correctly.
+
+### Sign-up flow
+
+```
+1. User enters email + password
+2. /api/auth/signUp/request-signup → creates OTP in DB, sends to email
+3. User enters OTP
+4. /api/auth/signUp/verify-otp → marks OTP as used
+5. User is redirected to dashboard (complete-signup route creates the user account)
+```
+
+### Sign-in flow
+
+```
+1. User enters email + password
+2. /api/auth/signIn → verifies credentials, creates a session
+3. Server sets two httpOnly cookies:
+   - accessToken  (JWT, expires 30 min)
+   - refreshToken (random UUID, expires 30 days)
+4. User is redirected to dashboard
+```
+
+### Token refresh flow
+
+When the access token expires, `middleware.ts` automatically calls `/api/auth/refreshToken`. If the refresh token is still valid, new tokens are issued and the user continues without interruption. If not, they are redirected to sign-in.
+
+### Protecting pages
+
+To protect a page so only signed-in users can access it, add its path to the `matcher` in `src/middleware.ts`:
+
+```ts
+export const config = {
+  matcher: ['/dashboard', '/inventory', '/your-new-protected-page'],
+};
+```
+
+### Getting the current user in an API route
+
+Call `AuthService.getUserSession()` inside your route handler (via the service layer). It reads the access token cookie and returns the user's `id` and `userEmail`. It throws a `ServiceError(401)` if the session is missing or expired.
+
+---
+
+## 15. Adding a New Feature — Step-by-Step Checklist
+
+Follow this exact order when building a new feature (e.g. "create a product").
+
+### Step 1 — Add the Zod schema
+
+In `src/validators/index.ts`:
+
+```ts
+export const createProductSchema = z.object({
+  name: z.string().min(1, 'Product name is required').max(100),
+  quantity: z.number().int().min(0),
+});
+```
+
+### Step 2 — Add types/DTOs
+
+In `src/types/product/product.types.ts`:
+
+```ts
+export interface ICreateProductDTO {
+  name: string;
+  quantity: number;
+  inventoryId: string;
+  tx?: Prisma.TransactionClient;
+}
+```
+
+### Step 3 — Add the repository method
+
+In `src/repositories/product.repo.ts`:
+
+```ts
+static async createProduct(data: ICreateProductDTO) {
+  const { name, quantity, inventoryId, tx = prisma } = data;
+  try {
+    return await tx.products.create({ data: { name, quantity, inventoryId } });
+  } catch {
+    throw new DatabaseError('Failed to create product');
+  }
+}
+```
+
+### Step 4 — Add the service method
+
+In `src/services/product/product.service.ts`:
+
+```ts
+static async createProduct(data: { name: string; quantity: number }): Promise<IProductResponseDTO> {
+  const userData = await AuthService.getUserSession();
+  const inventoryData = await InventoryService.getInventorySession();
+
+  const existing = await ProductRepository.findByNameInInventory({
+    name: data.name,
+    inventoryId: inventoryData.inventoryId,
+  });
+
+  if (existing) throw new ServiceError('Product already exists', 409);
+
+  const product = await ProductRepository.createProduct({
+    ...data,
+    inventoryId: inventoryData.inventoryId,
+  });
+
+  return { id: product.id, name: product.name, quantity: product.quantity };
+}
+```
+
+### Step 5 — Add the API route
+
+Create `src/app/api/products/create/route.ts`:
+
+```ts
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = await parseJsonBody(request);
+  const validation = createProductSchema.safeParse(body);
+  if (!validation.success) return validationErrorResponse(validation.error);
+
+  const product = await ProductService.createProduct(validation.data);
+  return NextResponse.json({ data: product }, { status: 201 });
+});
+```
+
+### Step 6 — Add the client API function
+
+In `src/features/product/product.api.ts`:
+
+```ts
+export const createProduct = async (name: string, quantity: number): Promise<void> => {
+  const validation = createProductSchema.safeParse({ name, quantity });
+  if (!validation.success) throw new ApiError(formatZodError(validation.error));
+
+  await productClient.post('/create', { name, quantity });
+};
+```
+
+### Step 7 — Add the query hook
+
+In `src/features/product/product.queries.ts`:
+
+```ts
+export const useCreateProduct = () =>
+  useNavigatingMutation({
+    mutationFn: (vars: { name: string; quantity: number }) =>
+      createProduct(vars.name, vars.quantity),
+    successMessage: 'Product created',
+    errorMessage: 'Failed to create product',
+  });
+```
+
+### Step 8 — Use in the component
+
+```tsx
+const { mutate, isPending } = useCreateProduct();
+mutate({ name: 'Widget', quantity: 10 });
+```
+
+### Step 9 — Run the checks
+
+```bash
+npm run lint
+npm run format
+npm run build
+```
+
+Fix every error before submitting.
+
+---
+
+## 16. Rules and Best Practices
+
+### Architecture rules (non-negotiable)
+
+- **Never import from a higher layer into a lower layer.** Services do not import from `features/`. Repositories do not import from services.
+- **All database queries go through repositories.** No `prisma.` calls in services, routes, or components.
+- **All business logic goes in services.** No logic in repositories or routes.
+- **All client data fetching uses TanStack Query hooks.** No raw `fetch` or `axios` calls in components.
+- **All validation schemas are in `src/validators/index.ts`.** No inline schemas anywhere else.
+- **All query keys are in `src/lib/query-keys.ts`.** No magic strings.
+- **All types are in `src/types/`.** No inline interfaces in service or route files.
+
+### Code quality rules
+
+- **One concern per function.** If a function does two things, split it.
+- **Descriptive names.** `getUserByEmail` is better than `getUser`. `createInventoryRole` is better than `createRole`.
+- **Do not add `console.log` to production code.** Remove debug logs before committing. `console.error` in services is acceptable for unexpected failures.
+- **Do not add comments that just re-state what the code does.** Comment only when the reason for doing something is not obvious.
+- **Never return a `status` field inside a JSON response body.** The HTTP status code is the status.
+
+### TypeScript rules
+
+- **Never use `any`.** If you don't know the type, use `unknown` and narrow it.
+- **Never use non-null assertion (`!`) without a clear reason.** If you write `value!`, there must be a guarantee above it that `value` is not null.
+- **Prefer `interface` for object shapes and `type` for unions and aliases.**
+
+---
+
+## 17. Automated Enforcement — How Rules Are Enforced
+
+The architecture rules in this guide are not just suggestions — they are enforced automatically at four layers. This section explains each layer in detail so you understand what is checking your code and why.
+
+### Layer 1 — Your editor (instant feedback)
+
+Install the **ESLint extension** for your editor (VS Code: `dbaeumer.vscode-eslint`). It reads `eslint.config.mjs` and highlights violations as you type — before you even save the file.
+
+This is the fastest feedback loop. A red underline in the editor costs nothing to fix. A CI failure costs a push cycle and review time.
+
+### Layer 2 — Pre-commit hook (Husky + lint-staged)
+
+**File:** `.husky/pre-commit`
+
+Runs automatically on every `git commit`. It executes `lint-staged`, which runs ESLint `--fix` and Prettier only on the files you have staged — not the whole codebase. This makes it fast (typically under 5 seconds).
+
+```
+git commit -m "feat: add product form"
+  → lint-staged runs on changed *.ts, *.tsx files
+      → ESLint --fix (auto-fixes what it can)
+      → Prettier --write
+  → if any errors remain that cannot be auto-fixed → commit is rejected
+  → fix the errors, re-stage, commit again
+```
+
+**What `lint-staged` is configured to run** (in `package.json`):
+
+```json
+"lint-staged": {
+  "*.{ts,tsx,js,jsx}": ["eslint --fix --max-warnings=0", "prettier --write"],
+  "*.{json,md,css}":   ["prettier --write"]
+}
+```
+
+### Layer 3 — Pre-push hook (Husky)
+
+**File:** `.husky/pre-push`
+
+Runs automatically on every `git push`. Executes two things in order:
+
+1. **`npm run arch-check`** — the custom architecture check script (see below)
+2. **`npm run build`** — the full TypeScript + Next.js production build
+
+The build step catches cross-file type errors that ESLint misses — for example, calling a service method with the wrong argument type, or a missing export that another file depends on.
+
+```
+git push origin feature/my-branch
+  → arch-check: scans all source files for structural violations
+  → npm run build: full TypeScript compile + Next.js build
+  → if either fails → push is rejected
+  → fix the error, commit the fix, push again
+```
+
+### Layer 4 — GitHub Actions (PR gate)
+
+**File:** `.github/workflows/pr-checks.yml`
+
+Four parallel jobs run on every pull request. All four must show a green checkmark before the PR can be merged (once you enable branch protection — see below).
+
+#### Job 1: Lint
+
+```bash
+npm run lint:ci   # eslint . --max-warnings=0
+```
+
+Runs ESLint across the entire codebase. Zero tolerance — any warning or error fails the job. This includes all layer boundary rules (see ESLint section below).
+
+#### Job 2: Format
+
+```bash
+npm run format:check   # prettier --check .
+```
+
+Verifies every file is correctly formatted. Does **not** modify files — if this fails, run `npm run format` locally and commit the result.
+
+#### Job 3: Build (TypeScript)
+
+```bash
+npm run build
+```
+
+Full Next.js production build. Catches TypeScript errors, missing imports, invalid JSX, and anything the compiler flags.
+
+#### Job 4: Architecture Check
+
+```bash
+npm run arch-check   # node scripts/arch-check.mjs
+```
+
+The custom script. See the full breakdown below.
+
+> **To enforce these as required checks in GitHub:** go to your repository → Settings → Branches → Add branch protection rule for `main` → enable **Require status checks to pass before merging** → search for and select: `Lint`, `Format`, `Build (TypeScript)`, `Architecture Check`.
+
+---
+
+### ESLint layer boundary rules
+
+**File:** `eslint.config.mjs`
+
+The ESLint config has per-directory `no-restricted-imports` rules that enforce who is allowed to import from whom. Violating these is an **ESLint error** — it fails both local lint and CI.
+
+```
+Browser (React components)
+        │  can import from: features/, lib/, types/, components/
+        ▼
+   features/
+        │  can import from: lib/, types/, validators/
+        │  CANNOT import from: services/, repositories/
+        ▼
+   app/api/ (route handlers)
+        │  can import from: services/, lib/, types/, validators/
+        │  CANNOT import from: repositories/, features/
+        ▼
+   services/
+        │  can import from: repositories/, lib/, types/, constants/
+        │  CANNOT import from: features/
+        ▼
+   repositories/
+        │  can import from: lib/repositories (Prisma client + error class), types/
+        │  CANNOT import from: services/, features/
+```
+
+| File pattern          | Restricted imports                   | Error message shown                                     |
+| --------------------- | ------------------------------------ | ------------------------------------------------------- |
+| `src/features/**`     | `@/services/**`, `@/repositories/**` | Feature modules must not import from server-only layers |
+| `src/components/**`   | `@/services/**`, `@/repositories/**` | Components must use query hooks from features/          |
+| `src/services/**`     | `@/features/**`                      | Services have no knowledge of the UI                    |
+| `src/repositories/**` | `@/services/**`, `@/features/**`     | Repositories are the lowest layer                       |
+| `src/app/api/**`      | `@/repositories/**`, `@/features/**` | Routes call services, not repositories directly         |
+
+Additional ESLint rules by layer:
+
+| Layer           | `no-console` rule                                                   |
+| --------------- | ------------------------------------------------------------------- |
+| `repositories/` | **error** — repos must never log; throw `DatabaseError` instead     |
+| `services/`     | **warn** — `console.log` disallowed; `console.error`/`warn` allowed |
+| `app/api/`      | **warn** — same as services                                         |
+
+`@typescript-eslint/no-explicit-any` is set to **error** globally — using `any` defeats TypeScript entirely.
+
+---
+
+### Architecture check script
+
+**File:** `scripts/arch-check.mjs`
+
+Run with `npm run arch-check`. Scans all `.ts`/`.tsx` files in `src/` and checks patterns that ESLint import rules cannot catch.
+
+#### Critical violations — exit code 1, blocks merge
+
+| Check                                                | What it catches                                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `new PrismaClient()` outside `repositories/index.ts` | Rogue database connection pools — a critical production bug                     |
+| Route files without `withErrorHandling`              | Unhandled exceptions escape to the browser as 500s with no useful error message |
+| `ToastService` called in `features/*.api.ts`         | Side effect in a pure function — breaks the two-file contract                   |
+| `router.push` / `useRouter` in `features/*.api.ts`   | Navigation logic in a pure function — breaks the two-file contract              |
+| `console.error` in `features/*.api.ts`               | Error logging in a pure function — `useNavigatingMutation` already does this    |
+| `prisma.{model}.{operation}` called in `services/`   | Service bypassing the repository layer — breaks data access encapsulation       |
+| `services/` imported in `repositories/`              | Upward dependency — repositories must have no knowledge of layers above them    |
+
+#### Warnings — exit code 0, logged but does not block merge
+
+| Check                                                      | What it catches                                                          |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `console.log` in `services/`, `repositories/`, `app/api/`  | Debug output left in server-side code                                    |
+| `useMutation` imported directly in `features/*.queries.ts` | Bypassing `useNavigatingMutation` — inconsistent toast/log/nav behaviour |
+| Inline `interface`/`type` definitions in `services/`       | Types defined inline instead of in `src/types/`                          |
+
+Warnings are not blocking but they should be resolved before shipping to production. The architecture check itself documents them clearly so they are not forgotten.
+
+---
+
+## 18. Known Limitations and Outstanding Items
+
+These are known issues in the codebase that have not been resolved yet. Do not work around them in ways that make them worse — flag them if they are blocking you.
+
+| Issue                                          | Location                                                     | Detail                                                                                                                                                                                                                      |
+| ---------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OTP generation is not cryptographically secure | `services/auth/otp-factory/otp.factory.ts`                   | Uses `Math.random()` — should use `crypto.getRandomValues()` for a 6-digit OTP. Not suitable for production.                                                                                                                |
+| Typo in constant name                          | `constants/tokens.constant.ts`                               | `AccessTokenCookieTIme` (capital `I` in `TIme`). Renaming it requires updating every import at the same time.                                                                                                               |
+| Email delivery not implemented                 | `services/email/`                                            | `email.service.ts` and `EmailServiceClass.ts` are entirely commented out. Currently the app uses EmailJS (browser-side) for OTP delivery. A server-side transactional email provider should replace this before production. |
+| Error pages not using App Router conventions   | `app/errorPages/`                                            | Should be converted to `error.tsx` / `not-found.tsx` files co-located with their routes, per Next.js App Router spec.                                                                                                       |
+| Class definitions in `types/`                  | `types/product/product.class.ts`, `types/user/user.class.ts` | Classes belong in `services/` or `models/`, not `types/`. The `types/` folder should only contain interfaces and type aliases.                                                                                              |
+| Debug `console.log` statements in middleware   | `middleware.ts`                                              | The refresh token flow has extensive debug logging that should be removed once the flow is stable in production.                                                                                                            |
+
+---
+
+## 19. Common Mistakes to Avoid
+
+| Mistake                                                               | Correct approach                                                                              |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Writing `prisma.users.findUnique(...)` inside a service               | Create a method in `UserRepository` and call that                                             |
+| Writing `new PrismaClient()` anywhere outside `repositories/index.ts` | Import `prisma` from `@/repositories`                                                         |
+| Using `useMutation` directly in a feature's `.queries.ts`             | Use `useNavigatingMutation` instead                                                           |
+| Putting `ToastService.success(...)` inside an API function            | Toasts belong in the hook (`queries.ts`), not the API function                                |
+| Defining a Zod schema inside a component or route file                | Add it to `src/validators/index.ts`                                                           |
+| Using `['products']` as a query key directly                          | Use `queryKeys.products.all()`                                                                |
+| Throwing a `ServiceError` inside a repository                         | Repositories throw `DatabaseError`, not `ServiceError`                                        |
+| Adding a validation guard (`if (!id) throw ...`) inside a repository  | Validation belongs in the service layer                                                       |
+| Returning `{ data: result, status: 201 }` from a route                | Return `{ data: result }` — the status belongs in `NextResponse.json({...}, { status: 201 })` |
+| Writing a try/catch inside a route handler                            | `withErrorHandling` does this — routes should have no try/catch                               |
+| Creating a new query key string without adding it to `query-keys.ts`  | Always add to `query-keys.ts` first                                                           |
+| Passing 6 separate arguments to a function                            | Use a DTO object — it's cleaner and easier to extend                                          |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-// eslint.config.js (using ESLint Flat Config with Prettier loaded from `.prettierrc`)
+// eslint.config.mjs — ESLint Flat Config (ESLint 9)
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -15,6 +15,9 @@ const __dirname = dirname(__filename);
 
 const prettierConfig = JSON.parse(readFileSync(resolve(__dirname, './.prettierrc.json'), 'utf-8'));
 
+// FlatCompat is kept for potential legacy plugin compatibility.
+// The recommendedConfig below is not applied — it is only used as a base
+// if compat.extends('eslint:recommended') is called, which it is not currently.
 const compat = new FlatCompat({
   baseDirectory: __dirname,
   recommendedConfig: {
@@ -25,11 +28,15 @@ const compat = new FlatCompat({
   },
 });
 
+void compat; // suppress unused variable warning
+
 export default [
+  // ─── Global ignores ────────────────────────────────────────────────────────
   {
-    ignores: ['node_modules', '.next', 'dist', 'build', 'eslint.config.mjs'],
+    ignores: ['node_modules', '.next', 'dist', 'build', 'eslint.config.mjs', 'scripts/'],
   },
 
+  // ─── Base rules — all source files ─────────────────────────────────────────
   {
     files: ['**/*.{js,ts,jsx,tsx}'],
     languageOptions: {
@@ -47,10 +54,10 @@ export default [
       next: nextPlugin,
     },
     rules: {
-      // Prettier
-      'prettier/prettier': 'error',
+      // ── Formatting ──────────────────────────────────────────────────────────
+      'prettier/prettier': ['error', prettierConfig],
 
-      // Unused imports
+      // ── Unused code ─────────────────────────────────────────────────────────
       'unused-imports/no-unused-imports': 'error',
       'unused-imports/no-unused-vars': [
         'warn',
@@ -62,11 +69,13 @@ export default [
         },
       ],
 
-      // TypeScript
-      '@typescript-eslint/no-explicit-any': 'warn',
+      // ── TypeScript ──────────────────────────────────────────────────────────
+      // Upgraded from warn → error: `any` defeats the purpose of TypeScript.
+      // Use `unknown` and narrow the type, or define a proper interface.
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
 
-      // Import order
+      // ── Import order ────────────────────────────────────────────────────────
       'import/order': [
         'warn',
         {
@@ -74,9 +83,147 @@ export default [
           'newlines-between': 'always',
         },
       ],
-      'prettier/prettier': ['error', prettierConfig],
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  },
+
+  // ─── Layer boundary: features/ ─────────────────────────────────────────────
+  // Features are client-side only. They communicate with the server exclusively
+  // through API route HTTP calls — never by importing server-side modules.
+  {
+    files: ['src/features/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/services', '@/services/**'],
+              message:
+                'Feature modules must not import from services/. ' +
+                'Services are server-only. Make an HTTP call via the feature\'s *.api.ts file instead.',
+            },
+            {
+              group: ['@/repositories', '@/repositories/**'],
+              message:
+                'Feature modules must not import from repositories/. ' +
+                'Repositories are server-only and must never run in the browser.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // ─── Layer boundary: components/ ───────────────────────────────────────────
+  // UI components interact with data only through TanStack Query hooks
+  // exported from features/. They must not reach into server-side layers.
+  {
+    files: ['src/components/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/services', '@/services/**'],
+              message:
+                'Components must not import from services/. ' +
+                'Use a query hook from features/ instead (e.g. useProducts, useCreateInventory).',
+            },
+            {
+              group: ['@/repositories', '@/repositories/**'],
+              message:
+                'Components must not import from repositories/. ' +
+                'Repositories are server-only.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // ─── Layer boundary: services/ ─────────────────────────────────────────────
+  // Services are pure business logic. They must not know about the HTTP layer
+  // (routes) or the client-side layer (features).
+  {
+    files: ['src/services/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/features', '@/features/**'],
+              message:
+                'Services must not import from features/. ' +
+                'features/ is client-side only. Services have no knowledge of the UI.',
+            },
+          ],
+        },
+      ],
+      // Allow console.error/warn in services (unexpected failures worth logging).
+      // Disallow console.log — use structured logging or remove debug output.
+      'no-console': ['warn', { allow: ['error', 'warn'] }],
+    },
+  },
+
+  // ─── Layer boundary: repositories/ ─────────────────────────────────────────
+  // Repositories are the lowest layer — pure data access.
+  // They must not depend on anything above them.
+  {
+    files: ['src/repositories/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/services', '@/services/**'],
+              message:
+                'Repositories must not import from services/. ' +
+                'Repositories are the lowest layer and must not have upward dependencies.',
+            },
+            {
+              group: ['@/features', '@/features/**'],
+              message:
+                'Repositories must not import from features/. ' +
+                'Repositories are server-only and have no knowledge of the UI.',
+            },
+          ],
+        },
+      ],
+      // Repositories should never log. Throw DatabaseError and let the caller decide.
+      'no-console': 'error',
+    },
+  },
+
+  // ─── Layer boundary: app/api/ (route handlers) ─────────────────────────────
+  // Routes are the HTTP boundary. They call services — never repositories directly.
+  // They must not import client-side modules.
+  {
+    files: ['src/app/api/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/repositories', '@/repositories/**'],
+              message:
+                'Route handlers must not import from repositories/. ' +
+                'Call a Service method instead — routes must not bypass the service layer.',
+            },
+            {
+              group: ['@/features', '@/features/**'],
+              message:
+                'Route handlers must not import from features/. ' +
+                'features/ is client-side only.',
+            },
+          ],
+        },
+      ],
+      // Route handlers should not log debug output.
+      'no-console': ['warn', { allow: ['error', 'warn'] }],
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,7 +100,7 @@ export default [
               group: ['@/services', '@/services/**'],
               message:
                 'Feature modules must not import from services/. ' +
-                'Services are server-only. Make an HTTP call via the feature\'s *.api.ts file instead.',
+                "Services are server-only. Make an HTTP call via the feature's *.api.ts file instead.",
             },
             {
               group: ['@/repositories', '@/repositories/**'],
@@ -133,8 +133,7 @@ export default [
             {
               group: ['@/repositories', '@/repositories/**'],
               message:
-                'Components must not import from repositories/. ' +
-                'Repositories are server-only.',
+                'Components must not import from repositories/. ' + 'Repositories are server-only.',
             },
           ],
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-prettier": "^5.5.0",
         "eslint-plugin-unused-imports": "^4.1.4",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.3.2",
         "prettier": "^3.6.2",
         "prisma": "^6.9.0",
         "tailwindcss": "^4",
@@ -2647,6 +2649,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3117,6 +3148,39 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3171,6 +3235,13 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3180,6 +3251,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -3479,6 +3560,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -4146,6 +4240,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -4378,6 +4479,19 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4616,6 +4730,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4837,6 +4967,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-function": {
@@ -5471,6 +5617,48 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.2.tgz",
+      "integrity": "sha512-xKqhC2AeXLwiAHXguxBjuChoTTWFC6Pees0SHPwOpwlvI3BH7ZADFPddAdN3pgo3aiKgPUx/bxE78JfUnxQnlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.2",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5526,6 +5714,56 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5615,6 +5853,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -6006,6 +6257,22 @@
       "peer": true,
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/openid-client": {
@@ -6568,6 +6835,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6577,6 +6861,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -6869,6 +7160,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -6876,6 +7180,36 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/sonner": {
@@ -6920,6 +7254,33 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -7027,6 +7388,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -7166,10 +7543,14 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-      "devOptional": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -7591,11 +7972,83 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,20 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "format": "prettier --write ."
+    "lint:ci": "eslint . --max-warnings=0",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "arch-check": "node scripts/arch-check.mjs",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "eslint --fix --max-warnings=0",
+      "prettier --write"
+    ],
+    "*.{json,md,css}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -53,6 +66,8 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.5.0",
     "eslint-plugin-unused-imports": "^4.1.4",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.3.2",
     "prettier": "^3.6.2",
     "prisma": "^6.9.0",
     "tailwindcss": "^4",

--- a/scripts/arch-check.mjs
+++ b/scripts/arch-check.mjs
@@ -86,15 +86,9 @@ function matchesPath(filePath, segment) {
 // ─── Collect all source files ─────────────────────────────────────────────────
 
 const allFiles = getAllFiles(SRC);
-const routeFiles = allFiles.filter(
-  (f) => matchesPath(f, '/app/api/') && f.endsWith('route.ts')
-);
-const serviceFiles = allFiles.filter(
-  (f) => matchesPath(f, '/services/') && !f.endsWith('lib.ts')
-);
-const repoFiles = allFiles.filter(
-  (f) => matchesPath(f, '/repositories/') && !f.endsWith('lib.ts')
-);
+const routeFiles = allFiles.filter((f) => matchesPath(f, '/app/api/') && f.endsWith('route.ts'));
+const serviceFiles = allFiles.filter((f) => matchesPath(f, '/services/') && !f.endsWith('lib.ts'));
+const repoFiles = allFiles.filter((f) => matchesPath(f, '/repositories/') && !f.endsWith('lib.ts'));
 const featureApiFiles = allFiles.filter(
   (f) => matchesPath(f, '/features/') && f.endsWith('.api.ts')
 );
@@ -121,7 +115,7 @@ console.log('─'.repeat(60));
       critical(
         file,
         '`new PrismaClient()` is only allowed in `src/repositories/index.ts`.\n' +
-          '             Import the shared singleton instead: `import prisma from \'@/repositories\''
+          "             Import the shared singleton instead: `import prisma from '@/repositories'"
       );
       violations++;
     }
@@ -305,7 +299,9 @@ if (errorCount === 0 && warnCount === 0) {
 }
 
 if (warnCount > 0) {
-  console.warn(`${YELLOW}${BOLD}⚠ ${warnCount} warning(s)${RESET} — review before shipping to production.`);
+  console.warn(
+    `${YELLOW}${BOLD}⚠ ${warnCount} warning(s)${RESET} — review before shipping to production.`
+  );
 }
 
 if (errorCount > 0) {

--- a/scripts/arch-check.mjs
+++ b/scripts/arch-check.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * Architecture Check Script
+ *
+ * Enforces structural patterns that ESLint import rules cannot catch.
+ * Complements eslint.config.mjs — ESLint handles what-can-import-what;
+ * this script handles how code behaves once it is imported.
+ *
+ * Exit codes:
+ *   0 = all checks passed (warnings may be present)
+ *   1 = one or more critical violations found
+ *
+ * Usage:
+ *   node scripts/arch-check.mjs          (normal run)
+ *   node scripts/arch-check.mjs --ci     (same — exit 1 on any critical)
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, 'src');
+
+let errorCount = 0;
+let warnCount = 0;
+let checkCount = 0;
+
+const RESET = '\x1b[0m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const GREEN = '\x1b[32m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+
+function rel(filePath) {
+  return relative(ROOT, filePath);
+}
+
+function critical(file, message) {
+  console.error(`  ${RED}${BOLD}✖ CRITICAL${RESET}  ${DIM}${rel(file)}${RESET}`);
+  console.error(`             ${message}\n`);
+  errorCount++;
+}
+
+function warning(file, message) {
+  console.warn(`  ${YELLOW}${BOLD}⚠ WARNING${RESET}   ${DIM}${rel(file)}${RESET}`);
+  console.warn(`             ${message}\n`);
+  warnCount++;
+}
+
+function passed(label) {
+  console.log(`  ${GREEN}✔${RESET} ${label}`);
+  checkCount++;
+}
+
+function getAllFiles(dir, extensions = ['.ts', '.tsx']) {
+  const results = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    if (['node_modules', '.next', 'dist', 'build'].includes(entry)) continue;
+    if (statSync(fullPath).isDirectory()) {
+      results.push(...getAllFiles(fullPath, extensions));
+    } else if (extensions.some((ext) => fullPath.endsWith(ext))) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function read(filePath) {
+  return readFileSync(filePath, 'utf-8');
+}
+
+function matchesPath(filePath, segment) {
+  return filePath.replace(/\\/g, '/').includes(segment);
+}
+
+// ─── Collect all source files ─────────────────────────────────────────────────
+
+const allFiles = getAllFiles(SRC);
+const routeFiles = allFiles.filter(
+  (f) => matchesPath(f, '/app/api/') && f.endsWith('route.ts')
+);
+const serviceFiles = allFiles.filter(
+  (f) => matchesPath(f, '/services/') && !f.endsWith('lib.ts')
+);
+const repoFiles = allFiles.filter(
+  (f) => matchesPath(f, '/repositories/') && !f.endsWith('lib.ts')
+);
+const featureApiFiles = allFiles.filter(
+  (f) => matchesPath(f, '/features/') && f.endsWith('.api.ts')
+);
+const featureQueryFiles = allFiles.filter(
+  (f) => matchesPath(f, '/features/') && f.endsWith('.queries.ts')
+);
+
+console.log(`\n${BOLD}Architecture Check${RESET}  —  ${allFiles.length} source files scanned\n`);
+console.log('─'.repeat(60));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CRITICAL CHECKS
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 1. No `new PrismaClient()` outside repositories/index.ts
+// ─────────────────────────────────────────────────────────
+{
+  const label = 'No raw PrismaClient instantiation outside repositories/index.ts';
+  let violations = 0;
+  for (const file of allFiles) {
+    if (matchesPath(file, '/repositories/index.ts')) continue;
+    const content = read(file);
+    if (/new\s+PrismaClient\s*\(/.test(content)) {
+      critical(
+        file,
+        '`new PrismaClient()` is only allowed in `src/repositories/index.ts`.\n' +
+          '             Import the shared singleton instead: `import prisma from \'@/repositories\''
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// 2. All route handlers must use withErrorHandling
+// ─────────────────────────────────────────────────
+{
+  const label = 'All route handlers wrapped with withErrorHandling';
+  let violations = 0;
+  for (const file of routeFiles) {
+    const content = read(file);
+    if (!/withErrorHandling/.test(content)) {
+      critical(
+        file,
+        'Route handler is missing `withErrorHandling`.\n' +
+          '             Wrap the exported handler: `export const POST = withErrorHandling(async (req) => { ... })`'
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// 3. API functions must be pure — no toast calls, no navigation
+// ─────────────────────────────────────────────────────────────
+{
+  const label = 'Feature API functions are pure (no side effects)';
+  let violations = 0;
+  for (const file of featureApiFiles) {
+    const content = read(file);
+    if (/ToastService/.test(content)) {
+      critical(
+        file,
+        '`ToastService` must not be called in API functions.\n' +
+          '             Move toast calls to the query hook in `*.queries.ts`.'
+      );
+      violations++;
+    }
+    if (/useRouter\b|router\.push\b/.test(content)) {
+      critical(
+        file,
+        '`router.push` / `useRouter` must not be used in API functions.\n' +
+          '             Move navigation to the query hook via the `redirectTo` option.'
+      );
+      violations++;
+    }
+    if (/console\.error\b|console\.warn\b/.test(content)) {
+      critical(
+        file,
+        'API functions must not log errors.\n' +
+          '             `useNavigatingMutation` logs errors automatically in its `onError` handler.'
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// 4. Services must not call prisma model methods directly
+// ────────────────────────────────────────────────────────
+// Services may import `prisma` for `$transaction()` — that is allowed.
+// Direct model queries (prisma.users.findUnique, etc.) must go through a Repository.
+{
+  const label = 'Services use Repositories — no direct prisma model calls';
+  const directQuery =
+    /\bprisma\.(users|sessions|email_otps|inventories|inventory_codes|user_inventory_roles|user_profiles)\./;
+  let violations = 0;
+  for (const file of serviceFiles) {
+    const content = read(file);
+    if (directQuery.test(content)) {
+      critical(
+        file,
+        'Service contains a direct `prisma.{model}.*` call.\n' +
+          '             Create a method in the relevant Repository and call that instead.'
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// 5. Repositories must not import from services
+// ─────────────────────────────────────────────
+{
+  const label = 'Repositories do not import from services (no upward dependency)';
+  let violations = 0;
+  for (const file of repoFiles) {
+    const content = read(file);
+    if (/@\/services\/|from ['"]\.\.\/services/.test(content)) {
+      critical(
+        file,
+        'Repository imports from `services/`. Repositories are the lowest layer and must\n' +
+          '             not depend on anything above them.'
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WARNING CHECKS
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 6. console.log in server-side code
+// ───────────────────────────────────
+{
+  const label = 'No console.log in server-side code';
+  const serverFiles = [...routeFiles, ...serviceFiles, ...repoFiles];
+  let violations = 0;
+  for (const file of serverFiles) {
+    const content = read(file);
+    const matches = [...content.matchAll(/console\.log\s*\(/g)];
+    if (matches.length > 0) {
+      warning(
+        file,
+        `${matches.length} console.log() call(s) — remove before shipping to production.`
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// 7. useMutation used directly in query files instead of useNavigatingMutation
+// ─────────────────────────────────────────────────────────────────────────────
+{
+  const label = 'Mutation hooks use useNavigatingMutation (not raw useMutation)';
+  let violations = 0;
+  for (const file of featureQueryFiles) {
+    const content = read(file);
+    // Detect direct import of useMutation from tanstack (not useNavigatingMutation)
+    if (
+      /import\s+\{[^}]*\buseMutation\b[^}]*\}\s+from\s+['"]@tanstack\/react-query['"]/.test(content)
+    ) {
+      warning(
+        file,
+        '`useMutation` imported directly from TanStack Query.\n' +
+          '             Use `useNavigatingMutation` from `@/lib/hooks/use-navigating-mutation` for consistent\n' +
+          '             toast, logging, and navigation behaviour.'
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// 8. Inline interface/type definitions in service files
+// ──────────────────────────────────────────────────────
+{
+  const label = 'No inline type definitions in service files';
+  let violations = 0;
+  for (const file of serviceFiles) {
+    const content = read(file);
+    // Match top-level interface or type alias declarations (not in imports)
+    const inlineTypes = content.match(/^(?:export\s+)?(?:interface|type)\s+\w+/gm);
+    if (inlineTypes) {
+      warning(
+        file,
+        `${inlineTypes.length} inline type definition(s): ${inlineTypes.map((t) => t.trim().split(/\s+/)[1] ?? t).join(', ')}.\n` +
+          '             Move these to `src/types/` so they can be shared across layers.'
+      );
+      violations++;
+    }
+  }
+  if (!violations) passed(label);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Summary
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log('\n' + '─'.repeat(60));
+
+if (errorCount === 0 && warnCount === 0) {
+  console.log(`\n${GREEN}${BOLD}✔ All ${checkCount} architecture checks passed.${RESET}\n`);
+  process.exit(0);
+}
+
+if (warnCount > 0) {
+  console.warn(`${YELLOW}${BOLD}⚠ ${warnCount} warning(s)${RESET} — review before shipping to production.`);
+}
+
+if (errorCount > 0) {
+  console.error(
+    `${RED}${BOLD}✖ ${errorCount} critical violation(s)${RESET} — fix these before merging.\n`
+  );
+  process.exit(1);
+}
+
+console.log('');

--- a/src/app/api/auth/getCoreToken/route.ts
+++ b/src/app/api/auth/getCoreToken/route.ts
@@ -1,48 +1,25 @@
-import jwt from 'jsonwebtoken';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import AuthService from '@/services/auth/auth.service';
 import { InventoryService } from '@/services/inventory/inventory.service';
+import { TokenFactory } from '@/services/auth/token-factory/token.factory';
+import { withErrorHandling } from '@/lib/route-helpers';
 
-export async function GET() {
-  try {
-    const userData = await AuthService.getUserSession();
-    if (!userData) throw Error('No User Data found');
+export const GET = withErrorHandling(async (_request: NextRequest) => {
+  const userData = await AuthService.getUserSession();
+  const inventoryData = await InventoryService.getInventorySession();
+  const roleData = await InventoryService.getUserRoleForInventory({
+    userId: userData.id,
+    inventoryId: inventoryData.inventoryId,
+  });
 
-    const inventoryData = await InventoryService.getInventorySession();
-    if (!inventoryData) throw Error('No Inventory Data found');
+  const tokenPayload = {
+    userId: userData.id,
+    inventoryId: inventoryData.inventoryId,
+    role: roleData.role,
+  };
 
-    const roleData = await InventoryService.getUserRoleForInventory({
-      userId: userData.id,
-      inventoryId: inventoryData.inventoryId,
-    });
-    if (!roleData) throw Error('No Role for this User found');
+  const authJwt = await TokenFactory.getCoreToken(tokenPayload);
 
-    const secretKey: string | undefined = process.env.JWT_SECRET;
-
-    if (!secretKey) {
-      throw new Error('JWT secret key is not defined');
-    }
-    const tokenPayload = {
-      userId: userData.id,
-      inventoryId: inventoryData.inventoryId,
-      role: roleData.role,
-    };
-
-    const tokenJwt = jwt.sign(tokenPayload, secretKey);
-
-    const responsePayload = {
-      userId: userData.id,
-      inventoryId: inventoryData.inventoryId,
-      role: roleData.role,
-      authJwt: process.env.NODE_ENV === 'development' ? tokenJwt : '',
-    };
-
-    const response: NextResponse = NextResponse.json({ data: responsePayload, status: 201 });
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    const statusCode = error instanceof Error ? 400 : 500;
-    return NextResponse.json({ error: errorMessage }, { status: statusCode });
-  }
-}
+  return NextResponse.json({ data: { ...tokenPayload, authJwt } }, { status: 200 });
+});

--- a/src/app/api/auth/refreshToken/route.ts
+++ b/src/app/api/auth/refreshToken/route.ts
@@ -1,35 +1,29 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
+import { refreshTokenSchema } from '@/validators';
 import AuthService from '@/services/auth/auth.service';
+import {
+  withErrorHandling,
+  extractRequestMeta,
+  parseJsonBody,
+  validationErrorResponse,
+} from '@/lib/route-helpers';
 
-export async function POST(request: Request) {
-  try {
-    const rawBody = await request.text();
-    let body = rawBody ? JSON.parse(rawBody) : {};
-    const { refreshTokenFromCookie } = body;
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = await parseJsonBody(request);
+  const validation = refreshTokenSchema.safeParse(body);
 
-    const { 'user-agent': userAgent = 'unknown', 'x-forwarded-for': forwarded } =
-      Object.fromEntries(request.headers);
-    const ipAddress = forwarded?.split(',')[0]?.trim() ?? 'unknown';
+  if (!validation.success) return validationErrorResponse(validation.error);
 
-    const serviceData = await AuthService.handleRefresh({
-      userAgent,
-      ipAddress,
-      refreshTokenFromCookie,
-    });
+  const { userAgent, ipAddress } = extractRequestMeta(request);
+  const { refreshTokenFromCookie } = validation.data;
 
-    if (!serviceData) {
-      return NextResponse.json({ error: 'Failed to refresh' }, { status: 400 });
-    }
+  const result = await AuthService.handleRefresh({ refreshTokenFromCookie, userAgent, ipAddress });
 
-    const { message, accessToken, refreshToken } = serviceData;
-
-    const response = NextResponse.json({ message, accessToken, refreshToken }, { status: 201 });
-
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    const statusCode = error instanceof Error ? 400 : 500;
-    return NextResponse.json({ error: errorMessage }, { status: statusCode });
+  if (!result) {
+    return NextResponse.json({ error: 'Session expired. Please sign in again' }, { status: 401 });
   }
-}
+
+  const { message, accessToken, refreshToken } = result;
+  return NextResponse.json({ message, accessToken, refreshToken }, { status: 200 });
+});

--- a/src/app/api/auth/signIn/route.ts
+++ b/src/app/api/auth/signIn/route.ts
@@ -1,40 +1,31 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { signInSchema } from '@/zod-validator';
+import { signInSchema } from '@/validators';
 import AuthService from '@/services/auth/auth.service';
-import { setTokensAtTheTimeOfSignUp } from '@/helpers/cookies';
+import { setTokensAtTheTimeOfSignUp } from '@/lib/cookies';
+import {
+  withErrorHandling,
+  extractRequestMeta,
+  parseJsonBody,
+  validationErrorResponse,
+} from '@/lib/route-helpers';
 
-export async function POST(request: Request) {
-  try {
-    const { 'user-agent': userAgent = 'unknown', 'x-forwarded-for': forwarded } =
-      Object.fromEntries(request.headers);
-    const ipAddress = forwarded?.split(',')[0]?.trim() ?? 'unknown';
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const { userAgent, ipAddress } = extractRequestMeta(request);
+  const body = await parseJsonBody(request);
+  const validation = signInSchema.safeParse(body);
 
-    const body = await request.json();
-    const validation = signInSchema.safeParse(body);
+  if (!validation.success) return validationErrorResponse(validation.error);
 
-    if (!validation.success) {
-      return NextResponse.json(
-        { error: 'Invalid input', details: validation.error.format() },
-        { status: 400 }
-      );
-    }
+  const { email, password } = validation.data;
+  const { message, accessToken, refreshToken } = await AuthService.handleSignInUser({
+    email,
+    password,
+    userAgent,
+    ipAddress,
+  });
 
-    const { email, password } = validation.data;
-
-    const { message, accessToken, refreshToken } = await AuthService.handleSignInUser({
-      email,
-      password,
-      userAgent,
-      ipAddress,
-    });
-
-    const response = NextResponse.json({ message }, { status: 201 });
-    setTokensAtTheTimeOfSignUp(accessToken, refreshToken, response);
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    const statusCode = error instanceof Error ? 400 : 500;
-    return NextResponse.json({ error: errorMessage }, { status: statusCode });
-  }
-}
+  const response = NextResponse.json({ message }, { status: 200 });
+  setTokensAtTheTimeOfSignUp(accessToken, refreshToken, response);
+  return response;
+});

--- a/src/app/api/auth/signUp/request-signup/route.ts
+++ b/src/app/api/auth/signUp/request-signup/route.ts
@@ -1,47 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 
-import { signUpSchema } from '@/zod-validator';
+import { signUpSchema } from '@/validators';
 import AuthService from '@/services/auth/auth.service';
-import { setSignUpData } from '@/helpers/cookies';
+import { setSignUpData } from '@/lib/cookies';
+import { withErrorHandling, parseJsonBody, validationErrorResponse } from '@/lib/route-helpers';
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    console.log('Raw request body:', body);
-    const validation = signUpSchema.safeParse(body);
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = await parseJsonBody(request);
+  const validation = signUpSchema.safeParse(body);
 
-    if (!validation.success) {
-      console.error('Signup Validation Error:', validation.error.format());
+  if (!validation.success) return validationErrorResponse(validation.error);
 
-      return NextResponse.json(
-        { error: 'Invalid input', details: validation.error.format() },
-        { status: 400 }
-      );
-    }
+  const { email, password } = validation.data;
+  const { message, otp } = await AuthService.handleRequestSignUp({ email, password });
 
-    const { email, password } = validation.data;
-
-    const { message, otp } = await AuthService.handleRequestSignUp({
-      email,
-      password,
-    });
-
-    const cookieStore = await cookies();
-
-    if (cookieStore.get('userPayload')) {
-      cookieStore.delete('userPayload');
-    }
-
-    const response = NextResponse.json({ message, otp }, { status: 201 });
-
-    await setSignUpData({ email, password }, response);
-
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    const statusCode = error instanceof Error ? 400 : 500;
-    console.error('Signup Error:', errorMessage);
-    return NextResponse.json({ error: errorMessage }, { status: statusCode });
-  }
-}
+  const response = NextResponse.json({ message, otp }, { status: 201 });
+  await setSignUpData({ email, password }, response);
+  return response;
+});

--- a/src/app/api/auth/signUp/verify-otp/route.ts
+++ b/src/app/api/auth/signUp/verify-otp/route.ts
@@ -1,47 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { otpVerificationSchema } from '@/zod-validator';
+import { otpVerificationSchema } from '@/validators';
 import AuthService from '@/services/auth/auth.service';
-import { setTokensAtTheTimeOfSignUp } from '@/helpers/cookies';
+import { setTokensAtTheTimeOfSignUp } from '@/lib/cookies';
+import {
+  withErrorHandling,
+  extractRequestMeta,
+  parseJsonBody,
+  validationErrorResponse,
+} from '@/lib/route-helpers';
 
-export async function POST(request: NextRequest) {
-  try {
-    const { 'user-agent': userAgent = 'unknown', 'x-forwarded-for': forwarded } =
-      Object.fromEntries(request.headers);
-    const ipAddress = forwarded?.split(',')[0]?.trim() ?? 'unknown';
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const { userAgent, ipAddress } = extractRequestMeta(request);
+  const body = await parseJsonBody(request);
+  const validation = otpVerificationSchema.safeParse(body);
 
-    const body = await request.json();
-    const validation = otpVerificationSchema.safeParse(body);
+  if (!validation.success) return validationErrorResponse(validation.error);
 
-    if (!validation.success) {
-      return NextResponse.json(
-        { error: 'Invalid input', details: validation.error.format() },
-        { status: 400 }
-      );
-    }
+  // handleVerifyOtp throws ServiceError on failure — no status check needed
+  await AuthService.handleVerifyOtp({ otp: validation.data.otp });
 
-    const { otp } = validation.data;
+  const { message, accessToken, refreshToken } = await AuthService.handleCompleteSignUp({
+    userAgent,
+    ipAddress,
+  });
 
-    const { status } = await AuthService.handleVerifyOtp({
-      otp,
-    });
-
-    if (status !== 200) {
-      return NextResponse.json({ error: 'Invalid OTP' }, { status: 400 });
-    }
-
-    const { message, accessToken, refreshToken } = await AuthService.handleCompleteSignUp({
-      userAgent,
-      ipAddress,
-    });
-
-    const response = NextResponse.json({ message }, { status: 201 });
-    setTokensAtTheTimeOfSignUp(accessToken, refreshToken, response);
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    const statusCode = error instanceof Error ? 400 : 500;
-
-    return NextResponse.json({ error: errorMessage }, { status: statusCode });
-  }
-}
+  const response = NextResponse.json({ message }, { status: 201 });
+  setTokensAtTheTimeOfSignUp(accessToken, refreshToken, response);
+  return response;
+});

--- a/src/app/api/inventory/create-inventory/route.ts
+++ b/src/app/api/inventory/create-inventory/route.ts
@@ -1,39 +1,23 @@
-import { cookies } from 'next/headers';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
+import { createInventorySchema } from '@/validators';
 import { InventoryService } from '@/services/inventory/inventory.service';
-import { setInventoryData } from '@/helpers/cookies';
-import { IInventoryResponseDTO } from '@/types/inventory/inventory.types';
+import { setInventoryData } from '@/lib/cookies';
+import { withErrorHandling, parseJsonBody, validationErrorResponse } from '@/lib/route-helpers';
 
-export async function POST(request: Request) {
-  try {
-    const body = await request.json();
-    const { name } = body;
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = await parseJsonBody(request);
+  const validation = createInventorySchema.safeParse(body);
 
-    if (!name || typeof name !== 'string') {
-      return new Response(JSON.stringify({ error: 'Invalid input' }), { status: 400 });
-    }
+  if (!validation.success) return validationErrorResponse(validation.error);
 
-    const createdInventory: IInventoryResponseDTO = await InventoryService.createInventory({
-      name: name,
-    });
+  const inventory = await InventoryService.createInventory({ name: validation.data.name });
 
-    if (!createdInventory?.inventoryId) {
-      return new Response(JSON.stringify({ error: 'Failed to create inventory' }), { status: 500 });
-    }
-
-    const cookieStore = await cookies();
-    if (cookieStore.get('inventoryData')) {
-      cookieStore.delete('inventoryData');
-    }
-
-    const response = NextResponse.json({ data: createdInventory, status: 201 });
-
-    await setInventoryData(createdInventory.inventoryId, response);
-
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    return new Response(JSON.stringify({ error: errorMessage }), { status: 500 });
+  if (!inventory?.inventoryId) {
+    return NextResponse.json({ error: 'Failed to create inventory' }, { status: 500 });
   }
-}
+
+  const response = NextResponse.json({ data: inventory }, { status: 201 });
+  await setInventoryData(inventory.inventoryId, response);
+  return response;
+});

--- a/src/app/api/inventory/join-inventory/route.ts
+++ b/src/app/api/inventory/join-inventory/route.ts
@@ -1,41 +1,23 @@
-import { cookies } from 'next/headers';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
+import { joinInventorySchema } from '@/validators';
 import { InventoryService } from '@/services/inventory/inventory.service';
-import { setInventoryData } from '@/helpers/cookies';
+import { setInventoryData } from '@/lib/cookies';
+import { withErrorHandling, parseJsonBody, validationErrorResponse } from '@/lib/route-helpers';
 
-export async function POST(request: Request) {
-  try {
-    const body = await request.json();
-    const { code } = body;
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = await parseJsonBody(request);
+  const validation = joinInventorySchema.safeParse(body);
 
-    if (!code) {
-      return new Response(JSON.stringify({ error: 'Invalid input' }), { status: 400 });
-    }
+  if (!validation.success) return validationErrorResponse(validation.error);
 
-    const joinedInventory = await InventoryService.joinInventory({ code: code });
+  const inventory = await InventoryService.joinInventory({ code: validation.data.code });
 
-    if (!joinedInventory) {
-      return new Response(JSON.stringify({ error: 'No inventory found with this code' }), {
-        status: 404,
-      });
-    }
-
-    if (!joinedInventory?.inventoryId) {
-      return new Response(JSON.stringify({ error: 'Failed to Join Inventory' }), { status: 400 });
-    }
-    const cookieStore = await cookies();
-    if (cookieStore.get('inventoryData')) {
-      cookieStore.delete('inventoryData');
-    }
-
-    const response = NextResponse.json({ data: joinedInventory, status: 201 });
-
-    await setInventoryData(joinedInventory.inventoryId, response);
-
-    return response;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Something went wrong';
-    return new Response(JSON.stringify({ error: errorMessage }), { status: 500 });
+  if (!inventory) {
+    return NextResponse.json({ error: 'No inventory found with this code' }, { status: 404 });
   }
-}
+
+  const response = NextResponse.json({ data: inventory }, { status: 200 });
+  await setInventoryData(inventory.inventoryId, response);
+  return response;
+});

--- a/src/app/auth/otp/page.tsx
+++ b/src/app/auth/otp/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from 'react';
 
 import InputOTPForm from '@/components/otp-form';
-import { useVerifyOtp } from '@/uiRoutes/api/auth/auth.queries';
+import { useVerifyOtp } from '@/features/auth/auth.queries';
 
 export default function OTPPage() {
   const { mutate: verifyOtpMutaion } = useVerifyOtp();

--- a/src/app/auth/signIn/page.tsx
+++ b/src/app/auth/signIn/page.tsx
@@ -2,7 +2,7 @@
 import { GalleryVerticalEnd } from 'lucide-react';
 
 import { LoginForm } from '@/components/login-form';
-import { useRequestLogIn } from '@/uiRoutes/api/auth/auth.queries';
+import { useRequestLogIn } from '@/features/auth/auth.queries';
 
 export default function SignIn() {
   const { mutate: requestLogIn, isPending } = useRequestLogIn();

--- a/src/app/auth/signUp/page.tsx
+++ b/src/app/auth/signUp/page.tsx
@@ -3,7 +3,7 @@ import { GalleryVerticalEnd } from 'lucide-react';
 import Link from 'next/link';
 
 import { SignUpForm } from '@/components/signup-form';
-import { useRequestSignUp } from '@/uiRoutes/api/auth/auth.queries';
+import { useRequestSignUp } from '@/features/auth/auth.queries';
 
 export default function SignUp() {
   const { mutate: requestSignUp, isPending } = useRequestSignUp();

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import JoinOrCreateInventory from '@/components/inventory/CreateOrJoinInventory';
-import { useCreateInventory, useJoinInventory } from '@/uiRoutes/api/inventory/inventory.queries';
+import { useCreateInventory, useJoinInventory } from '@/features/inventory/inventory.queries';
 
 export default function InventoryPage() {
   const { mutate: createInventory } = useCreateInventory();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/order */
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
@@ -17,7 +16,7 @@ export const metadata: Metadata = {
   description: 'Inventory management system for all businesses',
 };
 
-import { ReactQueryProvider } from '../uiRoutes/providers/ReactQueryProvider';
+import { ReactQueryProvider } from '@/providers/ReactQueryProvider';
 import ToastProvider from '@/services/toast/Toaster';
 export default function RootLayout({
   children,

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -61,7 +61,7 @@ export function LoginForm({ className, onLogIn, mutateData, ...props }: LoginFor
                 </div>
                 {error && <div>{error}</div>}
                 <Button type="submit" className="w-full">
-                  {isPending ? 'Logiing' : 'Login'}
+                  {isPending ? 'Logging in...' : 'Login'}
                 </Button>
               </div>
               <div className="text-center text-sm">

--- a/src/features/auth/auth.api.ts
+++ b/src/features/auth/auth.api.ts
@@ -1,0 +1,31 @@
+import { createApiClient } from '@/lib/http/api-client';
+import { sendOtpEmail } from '@/lib/email/emailjs';
+import { ApiError, formatZodError } from '@/lib/http/api-error';
+import { signUpSchema, signInSchema } from '@/validators';
+
+const authClient = createApiClient('/auth');
+
+export const requestSignUp = async (email: string, password: string): Promise<void> => {
+  const validation = signUpSchema.safeParse({ email, password });
+  if (!validation.success) throw new ApiError(formatZodError(validation.error));
+
+  const response = await authClient.post<{ message: string; otp?: string }>(
+    '/signUp/request-signup',
+    { email, password }
+  );
+
+  if (!response.otp) throw new ApiError('Failed to initiate sign up');
+
+  await sendOtpEmail({ toEmail: email, otp: response.otp });
+};
+
+export const requestLogIn = async (email: string, password: string): Promise<void> => {
+  const validation = signInSchema.safeParse({ email, password });
+  if (!validation.success) throw new ApiError(formatZodError(validation.error));
+
+  await authClient.post('/signIn', { email, password });
+};
+
+export const verifyOtp = async (otp: string): Promise<void> => {
+  await authClient.post('/signUp/verify-otp', { otp });
+};

--- a/src/features/auth/auth.queries.ts
+++ b/src/features/auth/auth.queries.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { requestSignUp, requestLogIn, verifyOtp } from './auth.api';
+
+import { useNavigatingMutation } from '@/lib/hooks/use-navigating-mutation';
+
+export const useRequestSignUp = () =>
+  useNavigatingMutation({
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      requestSignUp(email, password),
+    redirectTo: '/auth/otp',
+    successMessage: 'OTP sent to your email',
+  });
+
+export const useRequestLogIn = () =>
+  useNavigatingMutation({
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      requestLogIn(email, password),
+    redirectTo: '/dashboard',
+    successMessage: 'Logged in successfully',
+    errorMessage: 'Please check your credentials',
+  });
+
+export const useVerifyOtp = () =>
+  useNavigatingMutation({
+    mutationFn: ({ otp }: { otp: string }) => verifyOtp(otp),
+    redirectTo: '/dashboard',
+    successMessage: 'Account created successfully',
+    errorMessage: 'Incorrect OTP. Please try again',
+  });

--- a/src/features/inventory/inventory.api.ts
+++ b/src/features/inventory/inventory.api.ts
@@ -1,0 +1,21 @@
+import { createApiClient } from '@/lib/http/api-client';
+import {
+  TInventoryAxiosResponseDTO,
+  IInventoryResponseDTO,
+} from '@/types/inventory/inventory.types';
+
+const inventoryClient = createApiClient('/inventory');
+
+export const requestCreateInventory = async (name: string): Promise<IInventoryResponseDTO> => {
+  const response = await inventoryClient.post<TInventoryAxiosResponseDTO>('/create-inventory', {
+    name,
+  });
+  return response.data;
+};
+
+export const requestJoinInventory = async (code: string): Promise<IInventoryResponseDTO> => {
+  const response = await inventoryClient.post<TInventoryAxiosResponseDTO>('/join-inventory', {
+    code,
+  });
+  return response.data;
+};

--- a/src/features/inventory/inventory.queries.ts
+++ b/src/features/inventory/inventory.queries.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { requestCreateInventory, requestJoinInventory } from './inventory.api';
+
+import { useNavigatingMutation } from '@/lib/hooks/use-navigating-mutation';
+
+export const useCreateInventory = () =>
+  useNavigatingMutation({
+    mutationFn: (name: string) => requestCreateInventory(name),
+    redirectTo: '/dashboard',
+    errorMessage: 'Failed to create inventory. Please try again',
+  });
+
+export const useJoinInventory = () =>
+  useNavigatingMutation({
+    mutationFn: (code: string) => requestJoinInventory(code),
+    redirectTo: '/dashboard',
+    successMessage: 'You have successfully joined the inventory',
+    errorMessage: 'Invalid inventory code. Please try again',
+  });

--- a/src/features/product/product.api.ts
+++ b/src/features/product/product.api.ts
@@ -1,0 +1,8 @@
+import { createCoreServiceClient } from '@/lib/http/api-client';
+import { CProductModel } from '@/types/product/product.class';
+
+const productClient = createCoreServiceClient('/product');
+
+export const getAllProducts = async (): Promise<CProductModel> => {
+  return productClient.get<CProductModel>('/');
+};

--- a/src/features/product/product.queries.ts
+++ b/src/features/product/product.queries.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getAllProducts } from './product.api';
+
+import { queryKeys } from '@/lib/query-keys';
+
+export const useProducts = () =>
+  useQuery({
+    queryKey: queryKeys.products.all(),
+    queryFn: getAllProducts,
+    throwOnError: false,
+  });

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react';
+
+type TUseDebounceOptions = {
+  delay?: number;
+  leading?: boolean;
+  trailing?: boolean;
+};
+
+export function useDebounce<T>(value: T, options: TUseDebounceOptions) {
+  const { delay = 300, leading = false, trailing = true } = options;
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const leadingCalled = useRef(false);
+
+  useEffect(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+    const shouldCallLeading = leading && !leadingCalled.current;
+
+    if (shouldCallLeading) {
+      setDebouncedValue(value);
+      leadingCalled.current = true;
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      if (trailing) setDebouncedValue(value);
+      leadingCalled.current = false;
+    }, delay);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [value, delay, leading, trailing]);
+
+  return debouncedValue;
+}

--- a/src/lib/cookies/index.ts
+++ b/src/lib/cookies/index.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+import { encryptInventoryData, encryptSignupPayload } from '@/lib/crypto/encryption';
+import { AccessTokenCookieTIme, RefreshTokenCookieTime } from '@/constants/tokens.constant';
+import { Token } from '@/services/auth/token-factory/token.class';
+
+// --- Constants ---
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+// --- Shared cookie base options ---
+function baseCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/' as const,
+    sameSite: 'lax' as const,
+  };
+}
+
+// --- Setters ---
+
+export const setAccessToken = (token: string, response: NextResponse): NextResponse => {
+  response.cookies.set({
+    name: ACCESS_TOKEN_KEY,
+    value: token,
+    maxAge: AccessTokenCookieTIme,
+    ...baseCookieOptions(),
+  });
+  return response;
+};
+
+export const setRefreshToken = (token: string, response: NextResponse): NextResponse => {
+  response.cookies.set({
+    name: REFRESH_TOKEN_KEY,
+    value: token,
+    maxAge: RefreshTokenCookieTime,
+    ...baseCookieOptions(),
+  });
+  return response;
+};
+
+export const setTokensAtTheTimeOfSignUp = (
+  accessToken: string,
+  refreshToken: string,
+  response: NextResponse
+): void => {
+  clearAuthCookies(response);
+  setAccessToken(accessToken, response);
+  setRefreshToken(refreshToken, response);
+};
+
+export const setSignUpData = async (
+  signUpPayload: { email: string; password: string },
+  response: NextResponse
+): Promise<NextResponse> => {
+  const encrypted = await encryptSignupPayload(signUpPayload);
+  response.cookies.set({
+    name: 'userPayload',
+    value: encrypted,
+    maxAge: 3600,
+    ...baseCookieOptions(),
+  });
+  return response;
+};
+
+export const setInventoryData = async (
+  inventoryId: string,
+  response: NextResponse
+): Promise<NextResponse> => {
+  const encryptedInventoryData = await encryptInventoryData(inventoryId);
+  response.cookies.set({
+    name: 'inventoryData',
+    value: encryptedInventoryData,
+    maxAge: 60 * 60 * 24 * 7,
+    ...baseCookieOptions(),
+  });
+  return response;
+};
+
+// --- Getters ---
+
+export const getAccessToken = async (): Promise<Token | null> => {
+  const cookieStore = await cookies();
+  const value = cookieStore.get(ACCESS_TOKEN_KEY)?.value;
+  return value ? new Token(value) : null;
+};
+
+export const getRefreshToken = async (): Promise<Token | null> => {
+  const cookieStore = await cookies();
+  const value = cookieStore.get(REFRESH_TOKEN_KEY)?.value;
+  return value ? new Token(value) : null;
+};
+
+// --- Clearers ---
+
+export const clearAuthCookies = (response: NextResponse): void => {
+  const expiredOptions = { ...baseCookieOptions(), maxAge: 0, expires: new Date(0), value: '' };
+  response.cookies.set({ name: ACCESS_TOKEN_KEY, ...expiredOptions });
+  response.cookies.set({ name: REFRESH_TOKEN_KEY, ...expiredOptions });
+};

--- a/src/lib/crypto/encryption.ts
+++ b/src/lib/crypto/encryption.ts
@@ -1,0 +1,90 @@
+interface ISignUpPayload {
+  email: string;
+  password: string;
+}
+
+export async function encryptSignupPayload(payload: ISignUpPayload): Promise<string> {
+  return encryptStringAesGcm(JSON.stringify(payload));
+}
+
+export async function decryptSignUpPayload(encryptedBase64: string): Promise<ISignUpPayload> {
+  const json = await decryptStringAesGcm(encryptedBase64);
+  return JSON.parse(json) as ISignUpPayload;
+}
+
+export async function encryptInventoryData(inventoryId: string): Promise<string> {
+  return encryptStringAesGcm(inventoryId);
+}
+
+export async function decryptInventoryData(encryptedBase64: string): Promise<string> {
+  return decryptStringAesGcm(encryptedBase64);
+}
+
+// --- Internal ---
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const GCM_IV_BYTE_LENGTH = 12;
+
+let cachedAesGcmKey: CryptoKey | null = null;
+
+async function getAesGcmKey(): Promise<CryptoKey> {
+  if (!process.env.USER_PAYLOAD_SECRET) {
+    throw new Error('USER_PAYLOAD_SECRET environment variable is missing');
+  }
+  if (cachedAesGcmKey) return cachedAesGcmKey;
+  const secretBytes = encoder.encode(process.env.USER_PAYLOAD_SECRET);
+  const hash = await crypto.subtle.digest('SHA-256', secretBytes);
+  cachedAesGcmKey = await crypto.subtle.importKey('raw', hash, { name: 'AES-GCM' }, false, [
+    'encrypt',
+    'decrypt',
+  ]);
+  return cachedAesGcmKey;
+}
+
+async function encryptStringAesGcm(plain: string): Promise<string> {
+  const key = await getAesGcmKey();
+  const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_BYTE_LENGTH));
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoder.encode(plain));
+  const ctUint8 = new Uint8Array(ct);
+  const combined = new Uint8Array(iv.length + ctUint8.length);
+  combined.set(iv, 0);
+  combined.set(ctUint8, iv.length);
+  return toBase64(combined);
+}
+
+async function decryptStringAesGcm(b64: string): Promise<string> {
+  const key = await getAesGcmKey();
+  const combined = fromBase64(b64);
+  if (combined.length < GCM_IV_BYTE_LENGTH) throw new Error('Ciphertext too short');
+  const iv = combined.subarray(0, GCM_IV_BYTE_LENGTH).slice();
+  const ct = combined.subarray(GCM_IV_BYTE_LENGTH).slice();
+  const plainBuf = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct);
+  return decoder.decode(plainBuf);
+}
+
+function toBase64(bytes: Uint8Array): string {
+  if (typeof btoa === 'function') {
+    let binary = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+      binary += String.fromCharCode(...bytes.subarray(i, Math.min(i + chunk, bytes.length)));
+    }
+    return btoa(binary);
+  }
+  if (typeof Buffer !== 'undefined') return Buffer.from(bytes).toString('base64');
+  throw new Error('No base64 encoder available');
+}
+
+function fromBase64(b64: string): Uint8Array {
+  b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+  while (b64.length % 4) b64 += '=';
+  if (typeof atob === 'function') {
+    const binary = atob(b64);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+    return out;
+  }
+  if (typeof Buffer !== 'undefined') return new Uint8Array(Buffer.from(b64, 'base64'));
+  throw new Error('No base64 decoder available');
+}

--- a/src/lib/email/emailjs.ts
+++ b/src/lib/email/emailjs.ts
@@ -1,0 +1,29 @@
+import emailjs from 'emailjs-com';
+
+interface SendEmailParams {
+  toEmail: string;
+  otp: string;
+}
+
+export async function sendOtpEmail({ toEmail, otp }: SendEmailParams): Promise<void> {
+  const serviceId = process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID;
+  const templateId = process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID;
+  const userId = process.env.NEXT_PUBLIC_EMAILJS_USER_ID;
+
+  if (!serviceId || !templateId || !userId) {
+    throw new Error('EmailJS environment variables are not configured');
+  }
+
+  try {
+    const result = await emailjs.send(
+      serviceId,
+      templateId,
+      { email: toEmail, passcode: otp },
+      userId
+    );
+    console.log('Email sent:', result.status, result.text);
+  } catch (error) {
+    console.error('Failed to send OTP email:', error);
+    throw error;
+  }
+}

--- a/src/lib/hooks/use-navigating-mutation.ts
+++ b/src/lib/hooks/use-navigating-mutation.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import ToastService from '@/services/toast/toast.service';
+import { extractApiErrorMessage } from '@/lib/http/api-error';
+
+type UseNavigatingMutationOptions<TData, TVariables> = {
+  mutationFn: (variables: TVariables) => Promise<TData>;
+  redirectTo?: string;
+  successMessage?: string;
+  errorMessage?: string | ((error: Error) => string);
+  onSuccess?: (data: TData) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useNavigatingMutation<TData = void, TVariables = void>({
+  mutationFn,
+  redirectTo,
+  successMessage,
+  errorMessage,
+  onSuccess,
+  onError,
+}: UseNavigatingMutationOptions<TData, TVariables>) {
+  const router = useRouter();
+
+  return useMutation<TData, Error, TVariables>({
+    mutationFn,
+    onSuccess: (data) => {
+      if (successMessage) ToastService.success(successMessage);
+      onSuccess?.(data);
+      if (redirectTo) router.push(redirectTo);
+    },
+    onError: (error) => {
+      const msg =
+        errorMessage != null
+          ? typeof errorMessage === 'function'
+            ? errorMessage(error)
+            : errorMessage
+          : extractApiErrorMessage(error);
+      ToastService.error(msg);
+      console.error(error);
+      onError?.(error);
+    },
+  });
+}

--- a/src/lib/http/api-client.ts
+++ b/src/lib/http/api-client.ts
@@ -1,0 +1,43 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+import axiosInstance from './axios';
+import coreAxiosInstance from './core-axios';
+
+export interface ApiClient {
+  get<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
+  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
+  patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
+  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+}
+
+function buildApiClient(instance: AxiosInstance, basePath: string): ApiClient {
+  return {
+    get: async <T>(url: string, config?: AxiosRequestConfig) => {
+      const { data } = await instance.get<T>(`${basePath}${url}`, config);
+      return data;
+    },
+    post: async <T>(url: string, body?: unknown, config?: AxiosRequestConfig) => {
+      const { data } = await instance.post<T>(`${basePath}${url}`, body, config);
+      return data;
+    },
+    put: async <T>(url: string, body?: unknown, config?: AxiosRequestConfig) => {
+      const { data } = await instance.put<T>(`${basePath}${url}`, body, config);
+      return data;
+    },
+    patch: async <T>(url: string, body?: unknown, config?: AxiosRequestConfig) => {
+      const { data } = await instance.patch<T>(`${basePath}${url}`, body, config);
+      return data;
+    },
+    delete: async <T>(url: string, config?: AxiosRequestConfig) => {
+      const { data } = await instance.delete<T>(`${basePath}${url}`, config);
+      return data;
+    },
+  };
+}
+
+export const createApiClient = (basePath: string): ApiClient =>
+  buildApiClient(axiosInstance, basePath);
+
+export const createCoreServiceClient = (basePath: string): ApiClient =>
+  buildApiClient(coreAxiosInstance, basePath);

--- a/src/lib/http/api-error.ts
+++ b/src/lib/http/api-error.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from 'axios';
+import { ZodError } from 'zod';
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export function extractApiErrorMessage(error: unknown): string {
+  if (error instanceof AxiosError) {
+    return error.response?.data?.error ?? error.message ?? 'An unexpected error occurred';
+  }
+  if (error instanceof Error) return error.message;
+  return 'An unexpected error occurred';
+}
+
+export function formatZodError(error: ZodError): string {
+  return error.issues.map((issue) => issue.message).join('. ');
+}

--- a/src/lib/http/axios.ts
+++ b/src/lib/http/axios.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  timeout: 10000,
+});
+
+export default axiosInstance;

--- a/src/lib/http/core-axios.ts
+++ b/src/lib/http/core-axios.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+const coreAxiosInstance = axios.create({
+  baseURL: process.env.CORE_SERVICE_API_BASE_URL,
+  timeout: 10000,
+});
+
+coreAxiosInstance.interceptors.request.use(
+  async (config) => {
+    const token = await getCoreServiceToken();
+    config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+async function getCoreServiceToken(): Promise<string> {
+  const { data } = await axios.get<{ data: { authJwt: string } }>(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/getCoreToken`
+  );
+  if (!data?.data?.authJwt) throw new Error('Core service token unavailable');
+  return data.data.authJwt;
+}
+
+export default coreAxiosInstance;

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,10 @@
+export const queryKeys = {
+  products: {
+    all: () => ['products'] as const,
+    detail: (id: string) => ['products', id] as const,
+  },
+  inventory: {
+    all: () => ['inventory'] as const,
+    detail: (id: string) => ['inventory', id] as const,
+  },
+} as const;

--- a/src/lib/route-helpers.ts
+++ b/src/lib/route-helpers.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+
+import { ServiceError } from '@/services/lib';
+import { DatabaseError } from '@/repositories/lib';
+
+// --- HOF wrapper — eliminates try/catch from every route ---
+
+export function withErrorHandling(
+  handler: (request: NextRequest) => Promise<NextResponse>
+): (request: NextRequest) => Promise<NextResponse> {
+  return async (request) => {
+    try {
+      return await handler(request);
+    } catch (error) {
+      return buildErrorResponse(error);
+    }
+  };
+}
+
+// --- Request helpers ---
+
+export function extractRequestMeta(request: NextRequest): {
+  userAgent: string;
+  ipAddress: string;
+} {
+  const userAgent = request.headers.get('user-agent') ?? 'unknown';
+  const forwarded = request.headers.get('x-forwarded-for');
+  const ipAddress = forwarded?.split(',')[0]?.trim() ?? 'unknown';
+  return { userAgent, ipAddress };
+}
+
+export async function parseJsonBody<T = Record<string, unknown>>(request: NextRequest): Promise<T> {
+  try {
+    return (await request.json()) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
+// --- Response helpers ---
+
+export function validationErrorResponse(error: ZodError): NextResponse {
+  return NextResponse.json(
+    { error: 'Validation failed', details: error.format() },
+    { status: 400 }
+  );
+}
+
+export function buildErrorResponse(error: unknown): NextResponse {
+  if (error instanceof ServiceError || error instanceof DatabaseError) {
+    return NextResponse.json({ error: error.message }, { status: error.statusCode });
+  }
+  const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+  return NextResponse.json({ error: message }, { status: 500 });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 // middleware.ts
 import { NextRequest, NextResponse } from 'next/server';
 
-import { clearAuthCookies, setTokensAtTheTimeOfSignUp } from './helpers/cookies';
+import { clearAuthCookies, setTokensAtTheTimeOfSignUp } from './lib/cookies';
 import { TokenFactory } from './services/auth/token-factory/token.factory';
 
 export async function middleware(request: NextRequest) {

--- a/src/providers/ReactQueryProvider.tsx
+++ b/src/providers/ReactQueryProvider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+
+import { queryClient } from '@/lib/query-client';
+
+export function ReactQueryProvider({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,5 +1,11 @@
 import { PrismaClient } from '@prisma/client';
 
-export const prisma = new PrismaClient();
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
 
 export default prisma;

--- a/src/repositories/inventory.repo.ts
+++ b/src/repositories/inventory.repo.ts
@@ -17,60 +17,33 @@ export class InventoryRepository {
       const inventory = await tx.inventories.create({
         data: { name },
       });
-
       return { inventoryId: inventory.id };
     } catch {
       throw new DatabaseError('Failed to create inventory');
     }
   }
+
   static async createInventoryCodeData(data: IInventoryCodeDatabaseRequestDTO): Promise<void> {
+    const { inventoryId, code, tx } = data;
     try {
-      const { inventoryId, code, tx } = data;
-      if (!inventoryId || !code) {
-        throw new DatabaseError('Invalid inventory ID or code');
-      }
-      // Check if the inventory data exists for inventory_code table
-      const inventoryExists = await tx.inventory_codes.findUnique({
-        where: { id: inventoryId },
-      });
-
-      if (inventoryExists) {
-        throw new DatabaseError('Inventory code already exists');
-      }
-
       await tx.inventory_codes.create({
-        data: {
-          inventoryId,
-          code,
-        },
+        data: { inventoryId, code },
       });
     } catch {
       throw new DatabaseError('Failed to create inventory code');
     }
   }
+
   static async verifyAndGetInventory(
     data: InventoryCode
   ): Promise<IInventoryDatabaseResponseDTO | null> {
-    const { code } = data;
-
-    if (!code?.trim()) {
-      throw new DatabaseError('Invalid code');
-    }
-
     try {
-      const inventoryExists = await prisma.inventory_codes.findUnique({
-        where: { code },
+      const inventoryCode = await prisma.inventory_codes.findUnique({
+        where: { code: data.code },
       });
-
-      if (!inventoryExists) {
-        return null;
-      }
-      return { inventoryId: inventoryExists.inventoryId };
-    } catch (error) {
-      console.error('[verifyAndGetInventory] Error verifying inventory:', {
-        message: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : 'No stack trace',
-      });
+      if (!inventoryCode) return null;
+      return { inventoryId: inventoryCode.inventoryId };
+    } catch {
       throw new DatabaseError('Failed to verify inventory');
     }
   }
@@ -99,7 +72,7 @@ export class InventoryRepository {
         inventoryName: userRoleObject.inventories.name,
       };
     } catch {
-      throw new DatabaseError('Failed to check role');
+      throw new DatabaseError('Failed to check user role in inventory');
     }
   }
 
@@ -127,7 +100,7 @@ export class InventoryRepository {
         inventoryName: userInventoryObject.inventories.name,
       };
     } catch {
-      throw new DatabaseError('Failed to check role');
+      throw new DatabaseError('Failed to check user inventory');
     }
   }
 
@@ -136,69 +109,20 @@ export class InventoryRepository {
   ): Promise<{ inventoryId: string; name: string }> {
     const { inventoryId, userId, role, tx } = data;
     try {
-      if (!inventoryId || !userId || !role) {
-        console.error('[createInventoryRoleData] Validation failed', {
-          inventoryId,
-          userId,
-          role,
-        });
-        throw new DatabaseError('Invalid inventory ID, user ID or role');
-      }
-
-      if (!tx) {
-        console.error('[createInventoryRoleData] No tx/client provided');
-        throw new DatabaseError('Database transaction/client (tx) is required');
-      }
-
-      const userExists = await tx.users.findUnique({
-        where: { id: userId },
-      });
-
-      if (!userExists) {
-        console.error('[createInventoryRoleData] User not found', { userId });
-        throw new DatabaseError('User does not exist');
-      }
-
-      const userRoleExists = await tx.user_inventory_roles.findFirst({
-        where: {
+      await tx.user_inventory_roles.create({
+        data: {
           inventory_id: inventoryId,
           user_id: userId,
+          role,
         },
       });
 
-      if (userRoleExists) {
-        console.error('[createInventoryRoleData] User already has role', {
-          inventoryId,
-          userId,
-          existingRole: userRoleExists.role,
-        });
-        throw new DatabaseError('User already has a role in this inventory');
-      }
-
-      const inventoryData = await tx.inventories.findUnique({
+      const inventoryData = await tx.inventories.findUniqueOrThrow({
         where: { id: inventoryId },
         select: { id: true, name: true },
       });
 
-      if (!inventoryData) {
-        console.error('[createInventoryRoleData] Inventory not found', { inventoryId });
-        throw new DatabaseError('Inventory not found');
-      }
-
-      try {
-        await tx.user_inventory_roles.create({
-          data: {
-            inventory_id: inventoryData.id,
-            user_id: userId,
-            role,
-          },
-        });
-      } catch (dbCreateErr) {
-        throw dbCreateErr;
-      }
-
-      const result = { inventoryId: inventoryData.id, name: inventoryData.name ?? '' };
-      return result;
+      return { inventoryId: inventoryData.id, name: inventoryData.name };
     } catch {
       throw new DatabaseError('Failed to create inventory role');
     }

--- a/src/repositories/lib.ts
+++ b/src/repositories/lib.ts
@@ -1,4 +1,6 @@
 export class DatabaseError extends Error {
+  public readonly statusCode = 500;
+
   constructor(message: string) {
     super(message);
     this.name = 'DatabaseError';

--- a/src/repositories/otp.repo.ts
+++ b/src/repositories/otp.repo.ts
@@ -37,4 +37,16 @@ export class OtpRepository {
       throw new DatabaseError('Failed to mark OTP as used');
     }
   }
+
+  static async hasEmailBeenVerifiedByOtp(email: string): Promise<boolean> {
+    try {
+      const latestOtp = await prisma.email_otps.findFirst({
+        where: { email },
+        orderBy: { createdAt: 'desc' },
+      });
+      return !!latestOtp && latestOtp.used;
+    } catch {
+      throw new DatabaseError('Failed to fetch OTP verification status');
+    }
+  }
 }

--- a/src/repositories/session.repo.ts
+++ b/src/repositories/session.repo.ts
@@ -3,15 +3,11 @@ import { Prisma } from '@prisma/client';
 import { prisma } from './index';
 import { DatabaseError } from './lib';
 
+import { ICreateSessionDTO } from '@/types/auth/auth';
+
 export class SessionRepository {
-  static async createSession(
-    userId: string,
-    refreshTokenHash: string,
-    userAgent: string,
-    ipAddress: string,
-    expiresAt: Date,
-    tx: Prisma.TransactionClient = prisma
-  ) {
+  static async createSession(data: ICreateSessionDTO) {
+    const { userId, refreshTokenHash, userAgent, ipAddress, expiresAt, tx = prisma } = data;
     try {
       return await tx.sessions.create({
         data: {
@@ -43,9 +39,7 @@ export class SessionRepository {
     try {
       await tx.sessions.update({
         where: { id: sessionId },
-        data: {
-          revoked: true,
-        },
+        data: { revoked: true },
       });
     } catch {
       throw new DatabaseError('Failed to revoke session');

--- a/src/repositories/user.repo.ts
+++ b/src/repositories/user.repo.ts
@@ -6,14 +6,13 @@ import { DatabaseError } from './lib';
 export class UserRepository {
   static async getUserById(userId: string) {
     try {
-      const user = await prisma.users.findUnique({ where: { id: userId } });
-      return user;
+      return await prisma.users.findUnique({ where: { id: userId } });
     } catch {
       throw new DatabaseError('Failed to fetch user by id');
     }
   }
 
-  static async checkUserExistsByEmail(email: string) {
+  static async checkUserExistsByEmail(email: string): Promise<boolean> {
     try {
       const user = await prisma.users.findUnique({ where: { email } });
       return !!user;
@@ -30,7 +29,6 @@ export class UserRepository {
     }
   }
 
-  //This method is used in a transaction, so it accepts a Prisma.TransactionClient
   static async createUser(
     data: { email: string; passwordHash: string },
     tx: Prisma.TransactionClient = prisma
@@ -42,7 +40,6 @@ export class UserRepository {
     }
   }
 
-  //This method is used in a transaction, so it accepts a Prisma.TransactionClient
   static async createUserProfile(userId: string, tx: Prisma.TransactionClient = prisma) {
     try {
       return await tx.user_profiles.create({ data: { userId } });
@@ -51,66 +48,14 @@ export class UserRepository {
     }
   }
 
-  static async createEmailOtp(data: {
-    otpHash: string;
-    email: string;
-    expiresAt: Date;
-    createdAt: Date;
-    used: boolean;
-  }) {
-    try {
-      return await prisma.email_otps.create({ data });
-    } catch {
-      throw new DatabaseError('Failed to enter otp details in table');
-    }
-  }
-
-  static async getOtpByUniqueId(id: string) {
-    try {
-      return await prisma.email_otps.findUnique({ where: { id } });
-    } catch {
-      throw new DatabaseError('You are not registered with entered email');
-    }
-  }
-
   static async updateUserVerifiedStatus(email: string, tx: Prisma.TransactionClient = prisma) {
     try {
-      const updateData: { isVerified: boolean } = { isVerified: true };
       return await tx.users.update({
-        where: {
-          email: email,
-        },
-        data: updateData,
+        where: { email },
+        data: { isVerified: true },
       });
     } catch {
       throw new DatabaseError('Error on updating user verified status');
-    }
-  }
-
-  static async updateEmailOtpsStatus(id: string, tx: Prisma.TransactionClient = prisma) {
-    try {
-      const updateData: { used: boolean } = { used: true };
-      return await tx.email_otps.update({
-        where: {
-          id: id,
-        },
-        data: updateData,
-      });
-    } catch {
-      throw new DatabaseError('Error on updating user status on otp table');
-    }
-  }
-
-  static async getUserVerifiedStatus(email: string): Promise<boolean> {
-    try {
-      const latestOtp = await prisma.email_otps.findFirst({
-        where: { email },
-        orderBy: { createdAt: 'desc' },
-      });
-
-      return !!latestOtp && latestOtp.used;
-    } catch {
-      throw new DatabaseError('Failed to fetch user verified status');
     }
   }
 }

--- a/src/services/auth/auth.service.ts
+++ b/src/services/auth/auth.service.ts
@@ -7,103 +7,33 @@ import { OtpFactory } from './otp-factory/otp.factory';
 
 import { UserRepository } from '@/repositories/user.repo';
 import { SessionRepository } from '@/repositories/session.repo';
+import { OtpRepository } from '@/repositories/otp.repo';
 import prisma from '@/repositories';
 import { AccessToken, RefreshTokenExpiresAt } from '@/constants/tokens.constant';
-import { OtpRepository } from '@/repositories/otp.repo';
 import { OtpExpiresAt } from '@/constants/otp.constant';
-import { decryptSignUpPayload } from '@/helpers/encryption';
-
-interface ISignUpUserDTO {
-  email: string;
-  password: string;
-}
-
-interface ISignUpUserResponse {
-  message: string;
-}
-
-interface ISignInUserDTO {
-  email: string;
-  password: string;
-  userAgent: string;
-  ipAddress: string;
-}
-
-interface ISignInUserResponse {
-  message: string;
-  accessToken: string;
-  refreshToken: string;
-}
-
-interface IOtpVerificationDTO {
-  otp: string;
-}
-
-interface ICompleteSignUpRouteDTO {
-  userAgent: string;
-  ipAddress: string;
-}
-
-interface IRefreshTokenRequestDto {
-  refreshTokenFromCookie: string;
-  userAgent: string;
-  ipAddress: string;
-}
-
-interface IRefreshTokenResponseDto {
-  message: string;
-  accessToken: string;
-  refreshToken: string;
-}
+import { decryptSignUpPayload } from '@/lib/crypto/encryption';
+import type {
+  ISignUpUserDTO,
+  ISignInUserDTO,
+  ISignInUserResponseDTO,
+  IOtpVerificationDTO,
+  ICompleteSignUpDTO,
+  IRefreshTokenRequestDTO,
+  IRefreshTokenResponseDTO,
+} from '@/types/auth/auth';
 
 export default class AuthService {
-  static async handleSignUpUser(signUpData: ISignUpUserDTO): Promise<ISignUpUserResponse> {
-    const userWithEmail = await UserRepository.checkUserExistsByEmail(signUpData.email);
-    if (userWithEmail === true) {
-      throw new ServiceError('User with this email already exists');
+  static async handleRequestSignUp(
+    signUpData: ISignUpUserDTO
+  ): Promise<{ message: string; otp: string }> {
+    const userExists = await UserRepository.checkUserExistsByEmail(signUpData.email);
+    if (userExists) {
+      throw new ServiceError('User with this email already exists', 409);
     }
 
-    const hashedPassword = await PasswordFactory.generateHashPassword(signUpData.password);
-
-    try {
-      await prisma.$transaction(async (tx) => {
-        const newUser = await UserRepository.createUser(
-          {
-            email: signUpData.email,
-            passwordHash: hashedPassword,
-          },
-          tx
-        );
-
-        await UserRepository.createUserProfile(newUser.id, tx);
-      });
-    } catch {
-      throw new ServiceError('User registration failed');
-    }
-
-    return {
-      message: 'User successfully registered',
-    };
-  }
-
-  static async handleRequestSignUp(signUpData: ISignUpUserDTO) {
-    // Check if user already exists
-    const userWithEmail = await UserRepository.checkUserExistsByEmail(signUpData.email);
-    if (userWithEmail === true) {
-      throw new ServiceError('User with this email already exists');
-    }
-    // Generate OTP
     const otp = OtpFactory.generateOtp();
     const otpHash = await OtpFactory.generateOtpHash(otp);
 
-    // This will be used later in production to send OTP to user's email
-    // Send OTP to user's email
-    // await EmailService.sendOtpEmail({
-    //   toEmail: signUpData.email,
-    //   otp,
-    // });
-
-    // Insert OTP into the database
     try {
       await OtpRepository.createEmailOtp({
         otpHash,
@@ -112,70 +42,63 @@ export default class AuthService {
       });
     } catch (error) {
       console.error('Error creating OTP:', error);
-      throw new ServiceError('Failed to create OTP for user');
+      throw new ServiceError('Failed to send OTP. Please try again', 500);
     }
 
-    // We are returning the OTP in the response for testing purposes will be removed later
     return {
-      message: 'OTP successfully created and sent to email',
-      status: 200,
-      otp: otp, // This should be removed in production
+      message: 'OTP sent to email',
+      otp, // dev only — remove in production
     };
   }
 
-  static async handleVerifyOtp(otpVerificationData: IOtpVerificationDTO) {
+  static async handleVerifyOtp(otpVerificationData: IOtpVerificationDTO): Promise<void> {
     const userSignUpData = await this.getUserSignUpDataFromCookies();
     const latestValidOtp = await OtpRepository.getLatestValidOtpByEmail(userSignUpData.email);
+
     if (!latestValidOtp) {
-      throw new ServiceError('No valid OTP found for this email');
+      throw new ServiceError('No valid OTP found. Please request a new one', 404);
     }
-    const isOtpValid = OtpFactory.verifyOtp(otpVerificationData.otp, latestValidOtp.otpHash);
+
+    const isOtpValid = await OtpFactory.verifyOtp(otpVerificationData.otp, latestValidOtp.otpHash);
     if (!isOtpValid) {
-      console.error('Invalid OTP provided:', otpVerificationData.otp);
-      throw new ServiceError('Invalid OTP');
+      throw new ServiceError('Invalid OTP', 400);
     }
-    // Mark the OTP as used
+
     await OtpRepository.markOtpAsUsed(latestValidOtp.id);
-    return {
-      message: 'OTP successfully verified',
-      status: 200,
-    };
   }
 
-  static async handleCompleteSignUp(routeData: ICompleteSignUpRouteDTO) {
+  static async handleCompleteSignUp(
+    routeData: ICompleteSignUpDTO
+  ): Promise<ISignInUserResponseDTO> {
     const userSignUpData = await this.getUserSignUpDataFromCookies();
+
+    const isUserVerified = await OtpRepository.hasEmailBeenVerifiedByOtp(userSignUpData.email);
+    if (!isUserVerified) {
+      throw new ServiceError('Account not verified. Please complete OTP verification', 403);
+    }
+
     const hashedPassword = await PasswordFactory.generateHashPassword(userSignUpData.password);
     const refreshToken = TokenFactory.getRefreshToken();
-    const refreshTokenHash = await TokenFactory.getRefreshTokenHash(refreshToken);
-    const refreshTokenExpiresAt: Date = new Date(Date.now() + RefreshTokenExpiresAt);
+    const refreshTokenHash = await TokenFactory.hashRefreshToken(refreshToken.tokenValue);
+    const refreshTokenExpiresAt = new Date(Date.now() + RefreshTokenExpiresAt);
     let accessToken: string;
-
-    const isUserVerified = await UserRepository.getUserVerifiedStatus(userSignUpData.email);
-    if (!isUserVerified) {
-      throw new ServiceError('User is not verified');
-    }
 
     try {
       await prisma.$transaction(async (tx) => {
         const newUser = await UserRepository.createUser(
-          {
-            email: userSignUpData.email,
-            passwordHash: hashedPassword,
-          },
+          { email: userSignUpData.email, passwordHash: hashedPassword },
           tx
         );
-
         await UserRepository.createUserProfile(newUser.id, tx);
         await UserRepository.updateUserVerifiedStatus(userSignUpData.email, tx);
-        await SessionRepository.createSession(
-          newUser.id,
-          refreshTokenHash.tokenValue,
-          routeData.userAgent,
-          routeData.ipAddress,
-          refreshTokenExpiresAt,
-          tx
-        );
-
+        await SessionRepository.createSession({
+          userId: newUser.id,
+          refreshTokenHash,
+          userAgent: routeData.userAgent,
+          ipAddress: routeData.ipAddress,
+          expiresAt: refreshTokenExpiresAt,
+          tx,
+        });
         const accessTokenObj = await TokenFactory.getAccessToken({
           id: newUser.id,
           email: newUser.email,
@@ -183,149 +106,134 @@ export default class AuthService {
         accessToken = accessTokenObj.tokenValue;
       });
     } catch {
-      throw new ServiceError('User registration failed');
+      throw new ServiceError('Registration failed. Please try again', 500);
     }
 
-    // Clear the cookies after successful registration
     const cookieStore = await cookies();
     cookieStore.delete('userPayload');
 
     return {
-      message: 'User successfully registered',
+      message: 'Account created successfully',
       accessToken: accessToken!,
       refreshToken: refreshToken.tokenValue,
     };
   }
 
-  static async handleSignInUser(signInData: ISignInUserDTO): Promise<ISignInUserResponse> {
-    let accessToken: string;
-
-    const userWithEmail = await UserRepository.getUserByEmail(signInData.email);
-    if (!userWithEmail) {
-      throw new ServiceError('Please check your Credentials!');
+  static async handleSignInUser(signInData: ISignInUserDTO): Promise<ISignInUserResponseDTO> {
+    const user = await UserRepository.getUserByEmail(signInData.email);
+    if (!user) {
+      throw new ServiceError('Invalid email or password', 401);
     }
 
-    const hashedPassword = userWithEmail.passwordHash;
-    const actualPassword = signInData.password;
-    const checkPassword = await PasswordFactory.verify(actualPassword, hashedPassword);
-    if (!checkPassword) {
-      throw new ServiceError('Please check your Credentials!');
+    const passwordMatch = await PasswordFactory.verify(signInData.password, user.passwordHash);
+    if (!passwordMatch) {
+      throw new ServiceError('Invalid email or password', 401);
     }
+
     const refreshToken = TokenFactory.getRefreshToken();
-    const refreshTokenHash = await TokenFactory.getRefreshTokenHash(refreshToken);
-    const refreshTokenExpiresAt: Date = new Date(Date.now() + RefreshTokenExpiresAt);
+    const refreshTokenHash = await TokenFactory.hashRefreshToken(refreshToken.tokenValue);
+    const refreshTokenExpiresAt = new Date(Date.now() + RefreshTokenExpiresAt);
 
     try {
-      await SessionRepository.createSession(
-        userWithEmail.id,
-        refreshTokenHash.tokenValue,
-        signInData.userAgent,
-        signInData.ipAddress,
-        refreshTokenExpiresAt
-      );
+      await SessionRepository.createSession({
+        userId: user.id,
+        refreshTokenHash,
+        userAgent: signInData.userAgent,
+        ipAddress: signInData.ipAddress,
+        expiresAt: refreshTokenExpiresAt,
+      });
     } catch (error) {
       console.error('Failed to create session:', error);
-      throw new ServiceError('Unable to login due to server error');
+      throw new ServiceError('Sign in failed. Please try again', 500);
     }
 
-    const accessTokenObj = await TokenFactory.getAccessToken({
-      id: userWithEmail.id,
-      email: signInData.email,
-    });
-    accessToken = accessTokenObj.tokenValue;
+    const accessTokenObj = await TokenFactory.getAccessToken({ id: user.id, email: user.email });
 
     return {
-      message: 'User Login Successfully',
-      accessToken: accessToken!,
+      message: 'Signed in successfully',
+      accessToken: accessTokenObj.tokenValue,
       refreshToken: refreshToken.tokenValue,
     };
   }
 
   static async handleRefresh(
-    data: IRefreshTokenRequestDto
-  ): Promise<IRefreshTokenResponseDto | null> {
+    data: IRefreshTokenRequestDTO
+  ): Promise<IRefreshTokenResponseDTO | null> {
+    const refreshTokenHash = await TokenFactory.hashRefreshToken(data.refreshTokenFromCookie);
+    const session = await SessionRepository.getSession(refreshTokenHash);
+
+    if (!session || session.revoked || session.expiresAt < new Date()) {
+      return null;
+    }
+
+    const user = await UserRepository.getUserById(session.userId);
+    if (!user) {
+      throw new ServiceError('User not found', 404);
+    }
+
+    const newRefreshToken = TokenFactory.getRefreshToken();
+    const newRefreshTokenHash = await TokenFactory.hashRefreshToken(newRefreshToken.tokenValue);
+    const newRefreshTokenExpiresAt = new Date(Date.now() + RefreshTokenExpiresAt);
+    let accessToken: string | undefined;
+
     try {
-      const refreshTokenFromCookieHash = await TokenFactory.hashRefreshToken(
-        data.refreshTokenFromCookie
-      );
-      const sessionData = await SessionRepository.getSession(refreshTokenFromCookieHash);
-
-      if (!sessionData || sessionData.revoked || sessionData.expiresAt < new Date()) {
-        return null;
-      }
-
-      const refreshToken = TokenFactory.getRefreshToken();
-      const refreshTokenHash = await TokenFactory.getRefreshTokenHash(refreshToken);
-      const refreshTokenExpiresAt: Date = new Date(Date.now() + RefreshTokenExpiresAt);
-
-      const userObj = await UserRepository.getUserById(sessionData.userId);
-
-      if (!userObj) {
-        throw new ServiceError('Failed while getting user email');
-      }
-
-      let accessToken: string | undefined;
-
       await prisma.$transaction(async (tx) => {
-        await SessionRepository.revokeSession(sessionData.id, tx);
-
-        await SessionRepository.createSession(
-          sessionData.userId,
-          refreshTokenHash.tokenValue,
-          data.userAgent,
-          data.ipAddress,
-          refreshTokenExpiresAt,
-          tx
-        );
-
+        await SessionRepository.revokeSession(session.id, tx);
+        await SessionRepository.createSession({
+          userId: session.userId,
+          refreshTokenHash: newRefreshTokenHash,
+          userAgent: data.userAgent,
+          ipAddress: data.ipAddress,
+          expiresAt: newRefreshTokenExpiresAt,
+          tx,
+        });
         const accessTokenObj = await TokenFactory.getAccessToken({
-          id: sessionData.userId,
-          email: userObj.email,
+          id: session.userId,
+          email: user.email,
         });
         accessToken = accessTokenObj.tokenValue;
       });
-
-      return {
-        message: 'Tokens refreshed successfully',
-        accessToken: accessToken!,
-        refreshToken: refreshToken.tokenValue,
-      };
     } catch {
-      throw new ServiceError('Unable to refresh tokens due to server error');
+      throw new ServiceError('Token refresh failed. Please sign in again', 500);
     }
+
+    return {
+      message: 'Tokens refreshed successfully',
+      accessToken: accessToken!,
+      refreshToken: newRefreshToken.tokenValue,
+    };
   }
 
   static async getUserSession(): Promise<{ id: string; userEmail: string }> {
     const cookieStore = await cookies();
     const accessToken = cookieStore.get(AccessToken)?.value;
     if (!accessToken) {
-      throw new ServiceError('No access token found in cookies');
+      throw new ServiceError('Authentication required', 401);
     }
+
     const userPayload = await TokenFactory.verifyAccessToken(accessToken);
     if (!userPayload) {
-      throw new ServiceError('Invalid access token');
+      throw new ServiceError('Invalid or expired session. Please sign in again', 401);
     }
-    return {
-      id: userPayload.id,
-      userEmail: userPayload.email,
-    };
+
+    return { id: userPayload.id, userEmail: userPayload.email };
   }
 
-  /**Private Functions
-   * These functions are not exported and are used internally within the AuthService class.
-   */
-
-  private static async getUserSignUpDataFromCookies() {
+  private static async getUserSignUpDataFromCookies(): Promise<{
+    email: string;
+    password: string;
+  }> {
     const cookieStore = await cookies();
     const encryptedPayload = cookieStore.get('userPayload')?.value;
     if (!encryptedPayload) {
-      throw new ServiceError('No user data found in cookies');
+      throw new ServiceError('Sign-up session expired. Please start again', 400);
     }
 
     const { email, password } = await decryptSignUpPayload(encryptedPayload);
     if (!email || !password) {
-      throw new ServiceError('Invalid user data in cookies');
+      throw new ServiceError('Invalid sign-up session data', 400);
     }
+
     return { email, password };
   }
 }

--- a/src/services/auth/token-factory/token.factory.ts
+++ b/src/services/auth/token-factory/token.factory.ts
@@ -7,14 +7,23 @@ interface IAccessTokenPayload {
   email: string;
 }
 
+interface ICoreTokenPayload {
+  userId: string;
+  inventoryId: string;
+  role: string;
+}
+
 export class TokenFactory {
   static async getAccessToken(payload: IAccessTokenPayload): Promise<Token> {
     if (!payload?.id || !payload.email) {
       throw new Error('Invalid payload for access token');
     }
-
-    const tokenValue: string = await this.signAccessTokenWithJWT(payload);
+    const tokenValue = await this.signJwt(payload as unknown as JWTPayload, '30m');
     return new Token(tokenValue);
+  }
+
+  static async getCoreToken(payload: ICoreTokenPayload): Promise<string> {
+    return this.signJwt(payload as unknown as JWTPayload, '1h');
   }
 
   static getRefreshToken(): Token {
@@ -24,59 +33,37 @@ export class TokenFactory {
     return new Token(hex);
   }
 
-  static async getRefreshTokenHash(token: Token): Promise<Token> {
-    if (!(token instanceof Token)) {
-      throw new Error('Invalid token instance');
-    }
-
-    const encoder = new TextEncoder();
-    const data = encoder.encode(token.tokenValue);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-
-    return new Token(hashHex);
-  }
-
   static async hashRefreshToken(tokenValue: string): Promise<string> {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(tokenValue);
+    const data = new TextEncoder().encode(tokenValue);
     const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-    return hashHex;
+    return Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
   }
 
   static async verifyAccessToken(token: string): Promise<IAccessTokenPayload | null> {
-    const secret: string | undefined = process.env.JWT_SECRET;
-    const encoder = new TextEncoder();
-    const secretKey = encoder.encode(secret);
-
-    if (!secretKey) {
-      throw new Error('JWT secret key is not defined');
-    }
-
+    const secretKey = this.getSecretKey();
     try {
       const { payload } = await jwtVerify(token, secretKey);
       return payload as unknown as IAccessTokenPayload;
     } catch {
-      console.error(' Token verification failed');
+      console.error('Token verification failed');
       return null;
     }
   }
 
-  private static async signAccessTokenWithJWT(payload: IAccessTokenPayload): Promise<string> {
-    const secretKey = process.env.JWT_SECRET;
-    if (!secretKey) throw new Error('JWT secret key is not defined');
-    const key = new TextEncoder().encode(secretKey);
-    const jwtPayload = payload as unknown as JWTPayload;
-    const token = await new SignJWT(jwtPayload)
+  private static getSecretKey(): Uint8Array {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) throw new Error('JWT secret key is not defined');
+    return new TextEncoder().encode(secret);
+  }
+
+  private static async signJwt(payload: JWTPayload, expiresIn: string): Promise<string> {
+    const key = this.getSecretKey();
+    return new SignJWT(payload)
       .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
       .setIssuedAt()
+      .setExpirationTime(expiresIn)
       .sign(key);
-
-    return token;
   }
 }

--- a/src/services/inventory/inventory.service.ts
+++ b/src/services/inventory/inventory.service.ts
@@ -7,163 +7,121 @@ import prisma from '@/repositories';
 import { InventoryRepository } from '@/repositories/inventory.repo';
 import { IInventoryResponseDTO } from '@/types/inventory/inventory.types';
 import { DatabaseError } from '@/repositories/lib';
-import { decryptInventoryData } from '@/helpers/encryption';
+import { decryptInventoryData } from '@/lib/crypto/encryption';
 
 export class InventoryService {
   public static async createInventory(data: { name: string }): Promise<IInventoryResponseDTO> {
-    if (!data || data.name.length === 0) return null;
+    const userData = await AuthService.getUserSession();
+
+    const existing = await InventoryRepository.checkUserInventoryExists({
+      userId: userData.id,
+      name: data.name,
+    });
+
+    if (existing) {
+      return { inventoryId: existing.inventoryId, inventoryName: existing.inventoryName };
+    }
 
     try {
-      // Inventory-User Data
-      const userData = await AuthService.getUserSession();
-      if (!userData?.id) {
-        throw new ServiceError('User session not found');
-      }
+      const created = await prisma.$transaction(async (tx) => {
+        const newInventory = await InventoryRepository.createInventory({ name: data.name, tx });
 
-      const userInventoryExists = await InventoryRepository.checkUserInventoryExists({
-        userId: userData.id,
-        name: data.name,
-      });
-
-      if (userInventoryExists) {
-        return {
-          inventoryId: userInventoryExists.inventoryId,
-          inventoryName: userInventoryExists.inventoryName,
-        };
-      }
-
-      const createdInventory = await prisma.$transaction(async (tx) => {
-        try {
-          const newInventory = await InventoryRepository.createInventory({ name: data.name, tx });
-
-          if (!newInventory || !newInventory.inventoryId) {
-            throw new ServiceError('Failed to create new inventory');
-          }
-
-          const codeForNewInventory = await this.genereateUniqueInventoryCode();
-
-          await InventoryRepository.createInventoryCodeData({
-            inventoryId: newInventory.inventoryId,
-            code: codeForNewInventory,
-            tx,
-          });
-
-          await InventoryRepository.createInventoryRoleData({
-            inventoryId: newInventory.inventoryId,
-            userId: userData.id,
-            role: 'admin',
-            tx,
-          });
-
-          return {
-            inventoryId: newInventory.inventoryId,
-          };
-        } catch (error) {
-          console.error('Error details:', error);
-          throw error; // rethrow so Prisma rolls back
+        if (!newInventory?.inventoryId) {
+          throw new ServiceError('Failed to create inventory', 500);
         }
+
+        const code = await this.generateUniqueInventoryCode();
+
+        await InventoryRepository.createInventoryCodeData({
+          inventoryId: newInventory.inventoryId,
+          code,
+          tx,
+        });
+
+        await InventoryRepository.createInventoryRoleData({
+          inventoryId: newInventory.inventoryId,
+          userId: userData.id,
+          role: 'admin',
+          tx,
+        });
+
+        return { inventoryId: newInventory.inventoryId };
       });
-      return {
-        inventoryName: data.name,
-        inventoryId: createdInventory.inventoryId,
-      };
+
+      return { inventoryId: created.inventoryId, inventoryName: data.name };
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        throw error;
-      }
-      throw new ServiceError('An unexpected error occurred while creating inventory');
+      if (error instanceof ServiceError || error instanceof DatabaseError) throw error;
+      throw new ServiceError('Failed to create inventory. Please try again', 500);
     }
   }
+
   public static async joinInventory(data: { code: string }): Promise<IInventoryResponseDTO> {
-    const { code } = data;
+    const validatedInventory = await InventoryRepository.verifyAndGetInventory({ code: data.code });
+
+    if (!validatedInventory) {
+      return null;
+    }
+
+    const userData = await AuthService.getUserSession();
+
+    const existingRole = await InventoryRepository.checkUserRoleInInventory({
+      inventoryId: validatedInventory.inventoryId,
+      userId: userData.id,
+    });
+
+    if (existingRole) {
+      return { inventoryId: existingRole.inventoryId, inventoryName: existingRole.inventoryName };
+    }
+
     try {
-      const validatedInventory = await InventoryRepository.verifyAndGetInventory({ code });
-
-      if (!validatedInventory) {
-        console.error('[joinInventory] Invalid code provided:', { code });
-        return null;
-      }
-
-      const userData = await AuthService.getUserSession();
-
-      if (!userData?.id) {
-        throw new ServiceError('User session not found');
-      }
-
-      const userRoleExists = await InventoryRepository.checkUserRoleInInventory({
-        inventoryId: validatedInventory.inventoryId,
-        userId: userData.id,
-      });
-
-      if (userRoleExists) {
-        console.log('[joinInventory] User already has a role. Returning existing inventory info.');
-        return {
-          inventoryId: userRoleExists.inventoryId,
-          inventoryName: userRoleExists.inventoryName,
-        };
-      }
-
-      const createdInventory = await prisma.$transaction(async (tx) => {
-        const inventoryData = await InventoryRepository.createInventoryRoleData({
+      const inventoryData = await prisma.$transaction(async (tx) =>
+        InventoryRepository.createInventoryRoleData({
           inventoryId: validatedInventory.inventoryId,
           userId: userData.id,
           role: 'staff',
           tx,
-        });
-        return inventoryData;
-      });
+        })
+      );
 
-      const result = {
-        inventoryId: createdInventory.inventoryId,
-        inventoryName: createdInventory.name,
-      };
-
-      return result;
+      return { inventoryId: inventoryData.inventoryId, inventoryName: inventoryData.name };
     } catch (error) {
-      console.error('[joinInventory] ERROR - full details', {
-        errorMessage: error instanceof Error ? error.message : String(error),
-        errorName: error instanceof Error ? error.name : 'UnknownError',
-        stack: error instanceof Error ? error.stack : 'No stack',
-      });
-
-      if (error instanceof ServiceError) {
-        throw error;
-      }
-
-      throw new ServiceError('An unexpected error occurred while creating inventory');
+      if (error instanceof ServiceError || error instanceof DatabaseError) throw error;
+      throw new ServiceError('Failed to join inventory. Please try again', 500);
     }
   }
 
   public static async getInventorySession(): Promise<{ inventoryId: string }> {
     const cookieStore = await cookies();
-    const encryptedCookieData = cookieStore.get('inventoryData')?.value;
-    if (!encryptedCookieData) {
-      throw new ServiceError('No inventory data found in cookies');
+    const encryptedData = cookieStore.get('inventoryData')?.value;
+    if (!encryptedData) {
+      throw new ServiceError('No inventory selected. Please select an inventory', 404);
     }
-    const inventoryData = await decryptInventoryData(encryptedCookieData);
-    if (!inventoryData) {
-      throw new ServiceError('Invalid inventory data');
+
+    const inventoryId = await decryptInventoryData(encryptedData);
+    if (!inventoryId) {
+      throw new ServiceError('Invalid inventory session data', 400);
     }
-    return {
-      inventoryId: inventoryData,
-    };
+
+    return { inventoryId };
   }
 
   public static async getUserRoleForInventory(data: {
     userId: string;
     inventoryId: string;
   }): Promise<{ role: string }> {
-    const userRoleExists = await InventoryRepository.checkUserRoleInInventory({
+    const userRole = await InventoryRepository.checkUserRoleInInventory({
       inventoryId: data.inventoryId,
       userId: data.userId,
     });
-    if (!userRoleExists) throw new ServiceError('User Role for this inventory does not exist');
-    return {
-      role: userRoleExists.role,
-    };
+
+    if (!userRole) {
+      throw new ServiceError('User does not have access to this inventory', 403);
+    }
+
+    return { role: userRole.role };
   }
 
-  private static async genereateUniqueInventoryCode(): Promise<string> {
+  private static async generateUniqueInventoryCode(): Promise<string> {
     let code = '';
     let exists = true;
     while (exists) {
@@ -172,10 +130,10 @@ export class InventoryService {
     }
     return code;
   }
-  private static generateRandomInventoryCode(length: number = 6): string {
+
+  private static generateRandomInventoryCode(length = 6): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     const randomValues = crypto.getRandomValues(new Uint8Array(length));
-
     return Array.from(randomValues, (b) => chars[b % chars.length]).join('');
   }
 }

--- a/src/services/lib.ts
+++ b/src/services/lib.ts
@@ -1,5 +1,8 @@
 export class ServiceError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    public readonly statusCode: number = 400
+  ) {
     super(message);
     this.name = 'ServiceError';
   }

--- a/src/services/toast/toast.service.ts
+++ b/src/services/toast/toast.service.ts
@@ -36,10 +36,8 @@ export default class ToastService {
   static showZodError(error: unknown) {
     if (error instanceof ZodError) {
       error.issues.forEach((issue) => {
-        const field = issue.path.length > 0 ? issue.path.join('.') : 'Global';
         const message = this.formatErrorMessage(issue.message);
-        console.log(`Field Error [${field}]: ${message}`);
-        ToastService.error(`${message}`);
+        ToastService.error(message);
       });
     } else {
       ToastService.error('An unknown validation error occurred');

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -1,4 +1,62 @@
+import { Prisma } from '@prisma/client';
+
+// ---------------------------------------------------------------------------
+// Auth flow DTOs
+// ---------------------------------------------------------------------------
+
 export interface ISignUpDto {
   email: string;
   password: string;
+}
+
+export interface ISignUpUserDTO {
+  email: string;
+  password: string;
+}
+
+export interface ISignInUserDTO {
+  email: string;
+  password: string;
+  userAgent: string;
+  ipAddress: string;
+}
+
+export interface ISignInUserResponseDTO {
+  message: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface IOtpVerificationDTO {
+  otp: string;
+}
+
+export interface ICompleteSignUpDTO {
+  userAgent: string;
+  ipAddress: string;
+}
+
+export interface IRefreshTokenRequestDTO {
+  refreshTokenFromCookie: string;
+  userAgent: string;
+  ipAddress: string;
+}
+
+export interface IRefreshTokenResponseDTO {
+  message: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+// ---------------------------------------------------------------------------
+// Session DTOs
+// ---------------------------------------------------------------------------
+
+export interface ICreateSessionDTO {
+  userId: string;
+  refreshTokenHash: string;
+  userAgent: string;
+  ipAddress: string;
+  expiresAt: Date;
+  tx?: Prisma.TransactionClient;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,3 @@
 export interface INextResponse<T> {
   data: T;
-  status: number;
 }

--- a/src/types/inventory/inventory.types.ts
+++ b/src/types/inventory/inventory.types.ts
@@ -36,9 +36,3 @@ export type IInventoryRoleDatabaseRequestDTO = {
   role: UserRole;
   tx: Prisma.TransactionClient;
 };
-
-export type IInventoryRoleDatabaseRequestDTOWithoutTx = {
-  inventoryId: string;
-  userId: string;
-  role: UserRole;
-};

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const signUpSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z
+    .string()
+    .min(8, 'Password must be at least 8 characters')
+    .regex(
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
+      'Password must contain at least one letter, one number, and one special character'
+    ),
+});
+
+export const signInSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+export const otpVerificationSchema = z.object({
+  otp: z.string().length(6, 'OTP must be exactly 6 characters'),
+});
+
+export const refreshTokenSchema = z.object({
+  refreshTokenFromCookie: z.string().min(1, 'Refresh token is required'),
+});
+
+export const createInventorySchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Inventory name is required')
+    .max(100, 'Inventory name must be 100 characters or fewer'),
+});
+
+export const joinInventorySchema = z.object({
+  code: z.string().min(1, 'Inventory code is required').max(20, 'Invalid inventory code'),
+});


### PR DESCRIPTION
- Refactored build-deploy.yml to trigger only on pushes to main/develop — no longer runs on PRs. Split into separate verify and deploy jobs so deployment cannot proceed if the 
  build fails.                                                                                                                                                                    
  - Added dedicated pr-checks.yml with four parallel jobs (Lint, Format, Build, Architecture Check) that gate every pull request before merge.                                    
  - Added eslint-plugin layer boundary rules via no-restricted-imports — ESLint now errors if any layer imports from a layer it should not know about (features → services, repos
  → services, routes → repos, etc.).
  - Added scripts/arch-check.mjs — a custom Node.js script that enforces structural patterns ESLint cannot catch (missing withErrorHandling, raw PrismaClient instantiation, side
  effects in API functions, direct prisma model calls in services).
  - Added Husky pre-commit (lint-staged on staged files) and pre-push (arch-check + full build) hooks for local enforcement before code reaches GitHub.
  - Upgraded @typescript-eslint/no-explicit-any from warn → error globally.
  - Added lint:ci, format:check, and arch-check npm scripts.
  - Updated DEVELOPER_GUIDE.md with a full section on how every enforcement layer works.